### PR TITLE
Add conditional build support 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
     uses: "matrix-org/backend-meta/.github/workflows/sign-off.yml@v2"
 
   js-latest-main:
-    name: Tests (JS only, latest main)
+    name: Tests (JS only, latest develop)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3 # Checkout crypto tests
@@ -26,21 +26,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.21'
-      - name: Setup | Rust # TODO: Remove when we have conditional builds
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-      - name: Check out Rust SDK # TODO: Remove when we have conditional builds
-        run: |
-          ./install_uniffi_bindgen_go.sh
-          mkdir rust-sdk # don't use HTTPS path in rebuild_rust_sdk.sh so we can use the rust-cache before building
-          (wget -O - "https://github.com/matrix-org/matrix-rust-sdk/archive/kegan/complement-crypto.tar.gz" | tar -xz --strip-components=1 -C rust-sdk)
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "rust-sdk"
-      - name: Build Rust SDK # TODO: Remove when we have conditional builds
-        run: |
-          ./rebuild_rust_sdk.sh ./rust-sdk
       - name: "Install Complement Dependencies"
         run: |
           sudo apt-get update && sudo apt-get install -y libolm3 libolm-dev
@@ -55,17 +40,15 @@ jobs:
           docker pull mitmproxy/mitmproxy:10.1.5
           docker tag ghcr.io/matrix-org/synapse-service:v1.94.0 homeserver:latest
       - run: |
-          export LIBRARY_PATH="$(pwd)/rust-sdk/target/debug"
-          export LD_LIBRARY_PATH="$(pwd)/rust-sdk/target/debug"
           set -o pipefail &&
-          go test -v -json -timeout 15m ./tests | gotestfmt
+          go test -v -json -tags=jssdk -timeout 15m ./tests | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         name: Run Complement Crypto Tests
         env:
           COMPLEMENT_BASE_IMAGE: homeserver
           COMPLEMENT_ENABLE_DIRTY_RUNS: 1
           COMPLEMENT_CRYPTO_WRITE_CONTAINER_LOGS: 1
-          COMPLEMENT_CRYPTO_TEST_CLIENT_MATRIX: jj # only run JS tests (TODO: also runs some rust tests regardless)
+          COMPLEMENT_CRYPTO_TEST_CLIENT_MATRIX: jj # only run JS tests
           COMPLEMENT_SHARE_ENV_PREFIX: PASS_
           PASS_SYNAPSE_COMPLEMENT_DATABASE: sqlite
           DOCKER_BUILDKIT: 1
@@ -83,12 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3 # Checkout crypto tests
-      - name: Setup | Node.js 18.x # TODO: Remove when we have conditional builds
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: "internal/api/js/js-sdk/yarn.lock"
       - name: Setup | Go
         uses: actions/setup-go@v4
         with:
@@ -112,11 +89,6 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y libolm3 libolm-dev
           go install -v github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-      - name: Build JS SDK # TODO: Remove when we have conditional builds
-        run: |
-          cat ./internal/api/js/js-sdk/package.json
-          (cd ./internal/api/js/js-sdk && yarn install --frozen-lockfile && yarn build)
-          cp -r ./internal/api/js/js-sdk/dist/. ./internal/api/js/chrome/dist
       - name: Pull synapse service v1.94.0 and mitmproxy
         shell: bash
         run: |
@@ -127,14 +99,14 @@ jobs:
           export LIBRARY_PATH="$(pwd)/rust-sdk/target/debug"
           export LD_LIBRARY_PATH="$(pwd)/rust-sdk/target/debug"
           set -o pipefail &&
-          go test -v -json -timeout 15m ./tests | gotestfmt
+          go test -v -json -tags=rust -timeout 15m ./tests | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         name: Run Complement Crypto Tests
         env:
           COMPLEMENT_BASE_IMAGE: homeserver
           COMPLEMENT_ENABLE_DIRTY_RUNS: 1
           COMPLEMENT_CRYPTO_WRITE_CONTAINER_LOGS: 1
-          COMPLEMENT_CRYPTO_TEST_CLIENT_MATRIX: rr # only run rust tests (TODO: also runs some js tests regardless)
+          COMPLEMENT_CRYPTO_TEST_CLIENT_MATRIX: rr # only run rust tests
           COMPLEMENT_SHARE_ENV_PREFIX: PASS_
           PASS_SYNAPSE_COMPLEMENT_DATABASE: sqlite
           DOCKER_BUILDKIT: 1
@@ -259,7 +231,7 @@ jobs:
           export LIBRARY_PATH="$(pwd)/rust-sdk/target/debug"
           export LD_LIBRARY_PATH="$(pwd)/rust-sdk/target/debug"
           set -o pipefail &&
-          go test -v -json -timeout 15m ./tests | gotestfmt
+          go test -v -json -tags='jssdk,rust' -timeout 15m ./tests | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         name: Run Complement Crypto Tests
         env:

--- a/FAQ.md
+++ b/FAQ.md
@@ -75,12 +75,18 @@ mind your changes only applying to the native Rust (and NOT applying to Rust
 within the JavaScript client, which is compiled to WASM) then you can modify it
 in-place and then recompile it.
 
-Edit files inside the `rust-sdk` directory (which is just a copy of
-a specific version of `matrix-rust-sdk`) and then `cargo build -p
-matrix-sdk-ffi` inside that directory.
+Ensure you have `uniffi-bindgen-go` installed and on your `PATH`:
+```
+./install_uniffi_bindgen_go.sh
+```
 
-Make sure you launch the tests with LIBRARY_PATH pointing to
-`rust-sdk/target/debug` so that the built code gets used.
+Check out matrix-rust-sdk, edit your files and then run:
+```
+./rebuild_rust_sdk.sh /path/to/your/matrix-rust-sdk
+```
+
+Make sure you launch the tests with `LIBRARY_PATH` pointing to
+`$matrix-rust-sdk/target/debug` so that the built code gets used.
 
 Make sure you add `-count=1` on the command line when you re-run the tests,
 because changes to the rust here won't trigger the framework to re-execute a
@@ -213,29 +219,8 @@ Rust tests, but I have not actually tried it.
 
 ### React to changed interfaces in the Rust
 
-Prerequisites:
- - A working Rust installation (1.72+)
- - A working Go installation (1.19+?)
-
-This repo has bindings to the `matrix_sdk` crate in rust SDK, in order to mimic Element X.
-
-In order to generate these bindings, follow these instructions:
-- Check out https://github.com/matrix-org/matrix-rust-sdk/tree/kegan/complement-crypto (TODO: go back to main when
-main uses a versioned uniffi release e.g 0.25.2)
-- Get the bindings generator:
-```
-git clone https://github.com/kegsay/uniffi-bindgen-go.git # TODO: go back to NordSecurity once https://github.com/NordSecurity/uniffi-bindgen-go/pull/48 lands
-cd uniffi-bindgen-go
-git submodule init
-git submodule update
-cd ..
-cargo install uniffi-bindgen-go --path ./uniffi-bindgen-go/bindgen
-```
-- Compile the rust SDK: `cargo build -p matrix-sdk-ffi`. Check that `target/debug/libmatrix_sdk_ffi.a` exists.
-- **In the matrix-rust-sdk working directory**: generate the Go bindings to `../complement-crypto/internal/api/rust`: `uniffi-bindgen-go -o ../complement-crypto/internal/api/rust --config ../complement-crypto/uniffi.toml --library ./target/debug/libmatrix_sdk_ffi.a`
-- Patch up the generated code as it's not quite right:
-    * Add `// #cgo LDFLAGS: -lmatrix_sdk_ffi` immediately after `// #include <matrix_sdk_ffi.h>` at the top of `matrix_sdk_ffi.go`.
-- Sanity check compile `LIBRARY_PATH="$LIBRARY_PATH:/path/to/matrix-rust-sdk/target/debug" go test -c ./tests`
+This should now be done for you by following the steps in "Changing the native Rust directly". In the past, this involved
+lots of manual steps installing `uniffi-bindgen-go` and manually editing the generated code to patch it up so it compiled.
 
 #### Add console logs
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It's currently pretty awful to run, as you need toolchains for both Rust and JS.
 You need to build Rust SDK FFI bindings _and_ JS SDK before you can get this to run. You also need a Complement homeserver image. When that is setup:
 
 ```
-COMPLEMENT_BASE_IMAGE=homeserver:latest go test -v ./tests
+COMPLEMENT_BASE_IMAGE=homeserver:latest go test -tags='rust,jssdk' -v ./tests
 ```
 
 TODO: consider checking in working builds so you can git clone and run. Git LFS for `libmatrix_sdk_ffi.so` given it's 60MB?

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -8,13 +8,6 @@ import (
 	"github.com/matrix-org/complement/ct"
 )
 
-type ClientTypeLang string
-
-var (
-	ClientTypeRust ClientTypeLang = "rust"
-	ClientTypeJS   ClientTypeLang = "js"
-)
-
 type ClientType struct {
 	Lang ClientTypeLang // rust or js
 	HS   string         // hs1 or hs2

--- a/internal/api/lang.go
+++ b/internal/api/lang.go
@@ -1,0 +1,24 @@
+package api
+
+import "github.com/matrix-org/complement/ct"
+
+type ClientTypeLang string
+
+var (
+	ClientTypeRust ClientTypeLang = "rust"
+	ClientTypeJS   ClientTypeLang = "js"
+)
+
+// LanguageBindings is the interface any new language implementation needs to satisfy to
+// work with complement crypto.
+type LanguageBindings interface {
+	// PreTestRun is a hook which is executed before any tests run. This can be used to
+	// clean up old log files from previous runs.
+	PreTestRun()
+	// PostTestRun is a hook which is executed after all tests have run. This can be used
+	// to flush test logs.
+	PostTestRun()
+	// MustCreateClient is called to create a new client in this language. If the client cannot
+	// be created, the test should be failed by calling ct.Fatalf(t, ...).
+	MustCreateClient(t ct.TestLike, cfg ClientCreationOpts) Client
+}

--- a/internal/api/langs/lang.go
+++ b/internal/api/langs/lang.go
@@ -1,0 +1,27 @@
+// package langs contains language binding implementations
+//
+// This package would ideally be part of the `api` package but we can't do that
+// without creating circular imports, so here we are.
+package langs
+
+import (
+	"github.com/matrix-org/complement-crypto/internal/api"
+)
+
+// this map is populated _at runtime_ with known languages. It is custom to do this inside a func init()
+// for the language in question. Each language MUST be specified in a separate file with a custom build
+// tag to allow for conditional builds (we don't want to build your language unless the test runner needs it!)
+//
+// See the existing bindings for examples on how to do this.
+var knownLanguages map[api.ClientTypeLang]api.LanguageBindings = map[api.ClientTypeLang]api.LanguageBindings{}
+
+// SetLanguageBinding sets language bindings for the given language. Last write wins
+// if the same language is given more than once.
+func SetLangaugeBinding(l api.ClientTypeLang, b api.LanguageBindings) {
+	knownLanguages[l] = b
+}
+
+// GetLanguageBindings returns the language bindings for the given language, or nil if it doesn't exist.
+func GetLanguageBindings(l api.ClientTypeLang) api.LanguageBindings {
+	return knownLanguages[l]
+}

--- a/internal/api/langs/lang.go
+++ b/internal/api/langs/lang.go
@@ -17,7 +17,7 @@ var knownLanguages map[api.ClientTypeLang]api.LanguageBindings = map[api.ClientT
 
 // SetLanguageBinding sets language bindings for the given language. Last write wins
 // if the same language is given more than once.
-func SetLangaugeBinding(l api.ClientTypeLang, b api.LanguageBindings) {
+func SetLanguageBinding(l api.ClientTypeLang, b api.LanguageBindings) {
 	knownLanguages[l] = b
 }
 

--- a/internal/api/langs/lang_jssdk.go
+++ b/internal/api/langs/lang_jssdk.go
@@ -2,6 +2,7 @@
 
 package langs
 
+// Can't use tag name 'js' as that is used already for wasm bindings...
 import (
 	"fmt"
 	"os"
@@ -12,10 +13,9 @@ import (
 	"github.com/matrix-org/complement/must"
 )
 
-// Can't use tag name 'js' as that is used already for wasm bindings...
 func init() {
 	fmt.Println("Adding JS bindings")
-	SetLangaugeBinding(api.ClientTypeJS, &JSLanguageBindings{})
+	SetLanguageBinding(api.ClientTypeJS, &JSLanguageBindings{})
 }
 
 type JSLanguageBindings struct{}

--- a/internal/api/langs/lang_jssdk.go
+++ b/internal/api/langs/lang_jssdk.go
@@ -1,0 +1,38 @@
+//go:build jssdk
+
+package langs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/matrix-org/complement-crypto/internal/api"
+	"github.com/matrix-org/complement-crypto/internal/api/js"
+	"github.com/matrix-org/complement/ct"
+	"github.com/matrix-org/complement/must"
+)
+
+// Can't use tag name 'js' as that is used already for wasm bindings...
+func init() {
+	fmt.Println("Adding JS bindings")
+	SetLangaugeBinding(api.ClientTypeJS, &JSLanguageBindings{})
+}
+
+type JSLanguageBindings struct{}
+
+func (b *JSLanguageBindings) PreTestRun() {
+	// nuke persistent storage from previous run. We do this on startup rather than teardown
+	// to allow devs to introspect DBs / Chrome profiles if tests fail.
+	os.RemoveAll("./chromedp")
+	js.SetupJSLogs("./logs/js_sdk.log")
+}
+
+func (b *JSLanguageBindings) PostTestRun() {
+	js.WriteJSLogs()
+}
+
+func (b *JSLanguageBindings) MustCreateClient(t ct.TestLike, cfg api.ClientCreationOpts) api.Client {
+	client, err := js.NewJSClient(t, cfg)
+	must.NotError(t, "NewJSClient: %s", err)
+	return client
+}

--- a/internal/api/langs/lang_rust.go
+++ b/internal/api/langs/lang_rust.go
@@ -14,7 +14,7 @@ import (
 
 func init() {
 	fmt.Println("Adding Rust bindings")
-	SetLangaugeBinding(api.ClientTypeRust, &RustLanguageBindings{})
+	SetLanguageBinding(api.ClientTypeRust, &RustLanguageBindings{})
 }
 
 type RustLanguageBindings struct{}

--- a/internal/api/langs/lang_rust.go
+++ b/internal/api/langs/lang_rust.go
@@ -1,0 +1,38 @@
+//go:build rust
+
+package langs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/matrix-org/complement-crypto/internal/api"
+	"github.com/matrix-org/complement-crypto/internal/api/rust"
+	"github.com/matrix-org/complement/ct"
+	"github.com/matrix-org/complement/must"
+)
+
+func init() {
+	fmt.Println("Adding Rust bindings")
+	SetLangaugeBinding(api.ClientTypeRust, &RustLanguageBindings{})
+}
+
+type RustLanguageBindings struct{}
+
+func (b *RustLanguageBindings) PreTestRun() {
+	// nuke persistent storage from previous run. We do this on startup rather than teardown
+	// to allow devs to introspect DBs / Chrome profiles if tests fail.
+	os.RemoveAll("./rust_storage")
+	rust.DeleteOldLogs("rust_sdk_logs")
+	rust.DeleteOldLogs("rust_sdk_inline_script")
+	rust.SetupLogs("rust_sdk_logs")
+}
+
+func (b *RustLanguageBindings) PostTestRun() {
+}
+
+func (b *RustLanguageBindings) MustCreateClient(t ct.TestLike, cfg api.ClientCreationOpts) api.Client {
+	client, err := rust.NewRustClient(t, cfg)
+	must.NotError(t, "NewRustClient: %s", err)
+	return client
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/matrix-org/complement-crypto/internal/api"
+	"github.com/matrix-org/complement-crypto/internal/api/langs"
 )
 
 // The config for running Complement Crypto. This is configured using environment variables. The comments
@@ -44,6 +45,20 @@ type ComplementCrypto struct {
 
 func (c *ComplementCrypto) ShouldTest(lang api.ClientTypeLang) bool {
 	return c.clientLangs[lang]
+}
+
+// Bindings returns all the known language bindings for this particular complement-crypto configuration. Panics on
+// unknown bindings.
+func (c *ComplementCrypto) Bindings() []api.LanguageBindings {
+	bindings := make([]api.LanguageBindings, 0, len(c.clientLangs))
+	for l := range c.clientLangs {
+		b := langs.GetLanguageBindings(l)
+		if b == nil {
+			panic("unknown language: " + l)
+		}
+		bindings = append(bindings, b)
+	}
+	return bindings
 }
 
 func NewComplementCryptoConfigFromEnvVars() *ComplementCrypto {


### PR DESCRIPTION
Controlled by the tags `rust` and `jssdk` (can't use `js` as that is used by Go to mean 'wasm'.)

Update CI to only build the bits we need for each job.

Fixes https://github.com/matrix-org/complement-crypto/issues/22