### PR TITLE
Sleep for one second after starting sync, to make sure device keys are uploaded

### DIFF
--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement-crypto/internal/api"
@@ -206,6 +207,16 @@ func (c *TestContext) WithAliceAndBobSyncing(t *testing.T, callback func(alice, 
 		t.Helper()
 		c.WithClientSyncing(t, c.BobClientType, c.Bob, func(bob api.Client) {
 			t.Helper()
+
+			// Wait until Alice and Bob have probably both uploaded their room
+			// keys, so they can probably send each other messages.
+			// TODO: if we exposed client.encryption().wait_for_e2ee_initialization_tasks we could
+			// call that for Alice and Bob, instead of just sleeping for what we
+			// hope is long enough. See https://github.com/matrix-org/complement-crypto/issues/41
+			time.Sleep(time.Second)
+			// c.Alice.Client.Encryption().WaitForE2eeInitializationTasks()
+			// c.Bob.Client.Encryption().WaitForE2eeInitializationTasks()
+
 			callback(alice, bob)
 		})
 	})

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -123,10 +124,10 @@ func TestRoomKeyIsCycledAfterEnoughMessages(t *testing.T) {
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.Client) {
 			// And some messages were sent, but not enough to trigger resending
 			for i := 0; i < 4; i++ {
-				wantMsgBody := "Before we hit the threshold"
+				wantMsgBody := fmt.Sprintf("Before we hit the threshold %d", i)
 				waiter := bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 				alice.SendMessage(t, roomID, wantMsgBody)
-				waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
+				waiter.Waitf(t, 5*time.Second, "bob did not see alice's message '%s'", wantMsgBody)
 			}
 
 			// Sniff calls to /sendToDevice to ensure we see the new room key being sent.


### PR DESCRIPTION
Fixes https://github.com/matrix-org/complement-crypto/issues/41

This "fixes" the UTDs I was seeing when I ran `TestRoomKeyIsCycledAfterEnoughMessages` by adding a sleep inside `WithAliceAndBobSyncing`.

I wasn't sure where to add the sleep but this seemed a good place, because if you call this you are likely to want to send messages from Alice to Bob or vice versa.

If I added the sleep _before_ `WithAliceAndBobSyncing` the test still failed.

**Explanation of the problem**

After examining what was happening in detail, I discovered that Alice was fetching from `/keys/query` and finding that Bob existed, but had no devices. Because Bob was included in the list, even though he had no devices, he was added to the tracked users list, and marked as not "dirty", meaning we didn't try re-fetching keys before sending.

Before, when the `MemoryStore` did not save tracked users, we always re-fetched keys, but after I added support for storing this info, we ran into this problem.

I floated (with the Rust team) the idea of always considering a user "dirty" if they have no devices, but we rejected this idea because some users might genuinely have no devices, and this would cause us to fetch from `/keys/query` after every sync forever.

So it looks like the right answer is for us to wait in the test until Bob and Alice have uploaded their keys.

Unfortunately we don't have a good way of finding out when this has happened, so I've added a 1s sleep, which works on my machine.

We could consider exposing [wait_for_e2ee_initialization_tasks](https://github.com/matrix-org/matrix-rust-sdk/blob/1c1053afe6d88b637a53313a2d8d24f1cdd49834/crates/matrix-sdk/src/encryption/mod.rs#L1383) via FFI so we can call it, giving us a better option than a simple sleep.