### PR TITLE
Replace tcpdump with mitmdump

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -4,15 +4,15 @@
 Complement-Crypto is configured exclusively through the use of environment variables. These variables are described below. Additional environment variables can be used, and are outlined at https://github.com/matrix-org/complement/blob/main/ENVIRONMENT.md 
 Complement-Crypto always runs in dirty mode (homeservers exist for the entire duration of the test suite) for performance reasons.
 
+#### `COMPLEMENT_CRYPTO_MITMDUMP`
+The path to dump the output from `mitmdump`. This file can then be used with mitmweb to view all the HTTP flows in the test.  
+- Type: `string`
+- Default: ""
+
 #### `COMPLEMENT_CRYPTO_RPC_BINARY`
 The absolute path to the pre-built rpc binary file. This binary is generated via `go build -tags=jssdk,rust ./cmd/rpc`. This binary is used when running multiprocess tests. If this environment variable is not supplied, tests which try to use multiprocess clients will be skipped, making this environment variable optional.  
 - Type: `string`
 - Default: ""
-
-#### `COMPLEMENT_CRYPTO_TCPDUMP`
-If 1, automatically attempts to run `tcpdump` when the containers are running. Stops dumping when tests complete. This will probably require you to run `go test` with `sudo -E`. The `.pcap` file is written to `tests/test.pcap`.  
-- Type: `bool`
-- Default: 0
 
 #### `COMPLEMENT_CRYPTO_TEST_CLIENT_MATRIX`
 The client test matrix to run. Every test is run for each given permutation. The default matrix tests all JS/Rust permutations _ignoring federation_. 

--- a/FAQ.md
+++ b/FAQ.md
@@ -23,7 +23,7 @@ Now you can look around those log lines for any warnings/errors or unexpected be
 
 Sometimes the bug cannot be found via log files alone. You may want to see server logs. To do this, [enable writing container logs](https://github.com/matrix-org/complement-crypto/blob/main/ENVIRONMENT.md#complement_crypto_write_container_logs) then re-run the test. 
 
-Sometimes, even that isn't enough. Perhaps server logs aren't giving enough information. In that case, [enable tcpdump](https://github.com/matrix-org/complement-crypto/blob/main/ENVIRONMENT.md#complement_crypto_tcpdump) and open the `.pcap` file in Wireshark to see the raw HTTP request/responses made by all clients.
+Sometimes, even that isn't enough. Perhaps server logs aren't giving enough information. In that case, [enable mitmdump](https://github.com/matrix-org/complement-crypto/blob/main/ENVIRONMENT.md#complement_crypto_mitmdump) and open the dump file in mitmweb to see the raw HTTP request/responses made by all clients. If you don't have mitmweb, run `./open_mitmweb.sh` which will use the mitmproxy image.
 
 If you need to add console logging to clients, see below.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ go test -v -count=1 -tags=jssdk -timeout 15m ./tests
 `COMPLEMENT_CRYPTO_TEST_CLIENT_MATRIX` controls which SDK is used to create test clients, and the `-tags` option
 controls conditional compilation so other SDKs don't need to be compiled for the tests to run.
 
-To test interoperability between the SDKs, `tcpdump` the traffic, run extra multiprocess tests and more,
+To test interoperability between the SDKs, `mitmdump` the traffic, run extra multiprocess tests and more,
 see [ENVIRONMENT.md](ENVIRONMENT.md) for the full configuration options.
 
 *See [FAQ.md](FAQ.md) for more information around debugging.*

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,12 +35,11 @@ type ComplementCrypto struct {
 	// Derived from TestClientMatrix
 	clientLangs map[api.ClientTypeLang]bool
 
-	// Name: COMPLEMENT_CRYPTO_TCPDUMP
-	// Default: 0
-	// Description: If 1, automatically attempts to run `tcpdump` when the containers are running. Stops dumping when
-	// tests complete. This will probably require you to run `go test` with `sudo -E`. The `.pcap` file is written to
-	// `tests/test.pcap`.
-	TCPDump bool
+	// Name: COMPLEMENT_CRYPTO_MITMDUMP
+	// Default: ""
+	// Description: The path to dump the output from `mitmdump`. This file can then be used with mitmweb to view
+	// all the HTTP flows in the test.
+	MITMDump string
 
 	// Name: COMPLEMENT_CRYPTO_RPC_BINARY
 	// Default: ""
@@ -123,7 +122,7 @@ func NewComplementCryptoConfigFromEnvVars() *ComplementCrypto {
 		}
 	}
 	return &ComplementCrypto{
-		TCPDump:          os.Getenv("COMPLEMENT_CRYPTO_TCPDUMP") == "1",
+		MITMDump:         os.Getenv("COMPLEMENT_CRYPTO_MITMDUMP"),
 		RPCBinaryPath:    rpcBinaryPath,
 		TestClientMatrix: testClientMatrix,
 		clientLangs:      clientLangs,

--- a/internal/tests/client_test.go
+++ b/internal/tests/client_test.go
@@ -36,7 +36,7 @@ func Deploy(t *testing.T) *deploy.SlidingSyncDeployment {
 	if ssDeployment != nil {
 		return ssDeployment
 	}
-	ssDeployment = deploy.RunNewDeployment(t, "", false)
+	ssDeployment = deploy.RunNewDeployment(t, "", "")
 	return ssDeployment
 }
 

--- a/open_mitmweb.sh
+++ b/open_mitmweb.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ];
+then
+    echo "Opens a browser with mitmweb. Then you can open a dump file made via COMPLEMENT_CRYPTO_MITMDUMP. (requires on PATH: docker)"
+    exit 1
+fi
+
+# - use python3 instead of xdg-open because it's more portable (xdg-open doesn't work on MacOS). Sleep 1s and do it in the background.
+(sleep 1 && python3 -m webbrowser http://localhost:1445) &
+
+# - use same version as tests so we don't need to pull any new image. When the user CTRL+Cs this, the container quits.
+docker run --rm -p 1445:8081 mitmproxy/mitmproxy:10.1.5  mitmweb --web-host 0.0.0.0

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -59,7 +59,7 @@ func Deploy(t *testing.T) *deploy.SlidingSyncDeployment {
 		t.Fatalf("failed to find working directory: %s", err)
 	}
 	mitmProxyAddonsDir := filepath.Join(workingDir, "mitmproxy_addons")
-	ssDeployment = deploy.RunNewDeployment(t, mitmProxyAddonsDir, complementCryptoConfig.TCPDump)
+	ssDeployment = deploy.RunNewDeployment(t, mitmProxyAddonsDir, complementCryptoConfig.MITMDump)
 	return ssDeployment
 }
 


### PR DESCRIPTION
Fixes https://github.com/matrix-org/complement-crypto/issues/63

This is a superior replacement because it:
 - doesn't need `sudo`
 - has a UI bundled with it automatically (no need to install Wireshark)
 - is HTTP specific so the UI is more intuitive (unlike Wireshark which need filter=http and to "view HTTP flows" for it to be legible)

This will become increasingly important as other devs start adding tests, as they will need to be able to easily debug tests when they fail.

This ends up looking like:

<img width="1532" alt="Screenshot 2024-05-22 at 12 03 32" src="https://github.com/matrix-org/complement-crypto/assets/7190048/61c59d4e-9adb-40ff-b82b-3fc8b24efd96">
