### PR TITLE
Fix flakey TestRoomKeyIsCycledAfterEnoughTime

### DIFF
--- a/install_uniffi_bindgen_go.sh
+++ b/install_uniffi_bindgen_go.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 set -o pipefail
 
-git clone --depth 1 --branch main https://github.com/kegsay/uniffi-bindgen-go _temp_uniffi_bindgen_go;
+git clone --depth 1 --branch main https://github.com/NordSecurity/uniffi-bindgen-go _temp_uniffi_bindgen_go;
 (cd _temp_uniffi_bindgen_go && git submodule init && git submodule update && cargo install uniffi-bindgen-go --path ./bindgen);
 rm -rf _temp_uniffi_bindgen_go;


### PR DESCRIPTION
Tests could fail with:
```
  thread 'tokio-runtime-worker' panicked at /home/runner/work/matrix-rust-sdk/matrix-rust-sdk/crates/matrix-sdk-crypto/src/session_manager/group_sessions.rs:211:9:
  Session expired
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Due to this assertion being violated: `assert!(!session.expired(), "Session expired");`.

My guess is that the code does something like:
 - check if expired session
 - if expired, then renew it
 - encrypt message, after first asserting that we are using a valid session

This is unsafe, as it's effectively a read-modify-write race condition, since the session can expire due to time i.e the first check passes because it will expire in 1 nanosecond, then the assertion fails when encrypting.

The fix is to just increase the rotation period, so the chance of it expiring during the encrypt calls is reduced.

Also repoint `install_uniffi_bindgen_go.sh` to upstream.