### PR TITLE
Use the new session path in the client builder.

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -74,7 +74,7 @@ func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, erro
 	if opts.PersistentStorage {
 		// @alice:hs1, FOOBAR => alice_hs1_FOOBAR
 		username = strings.Replace(opts.UserID[1:], ":", "_", -1) + "_" + opts.DeviceID
-		ab = ab.BasePath("rust_storage").Username(username)
+		ab = ab.SessionPath("rust_storage/" + username).Username(username)
 	}
 	client, err := ab.Build()
 	if err != nil {


### PR DESCRIPTION
Let's see if this helps CI on https://github.com/matrix-org/matrix-rust-sdk/pull/3514