### PR TITLE
Make mitm/callback options more composable

### DIFF
--- a/internal/deploy/callback_addon.go
+++ b/internal/deploy/callback_addon.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/must"
 )
@@ -33,7 +32,7 @@ func (cd CallbackData) String() string {
 // NewCallbackServer runs a local HTTP server that can read callbacks from mitmproxy.
 // Returns the URL of the callback server for use with WithMITMOptions, along with a close function
 // which should be called when the test finishes to shut down the HTTP server.
-func NewCallbackServer(t *testing.T, deployment complement.Deployment, cb func(CallbackData)) (callbackURL string, close func()) {
+func NewCallbackServer(t *testing.T, hostnameRunningComplement string, cb func(CallbackData)) (callbackURL string, close func()) {
 	if lastTestName != "" {
 		t.Logf("WARNING[%s]: NewCallbackServer called without closing the last one. Check test '%s'", t.Name(), lastTestName)
 	}
@@ -66,7 +65,7 @@ func NewCallbackServer(t *testing.T, deployment complement.Deployment, cb func(C
 		Handler: mux,
 	}
 	go srv.Serve(ln)
-	return fmt.Sprintf("http://%s:%d", deployment.GetConfig().HostnameRunningComplement, port), func() {
+	return fmt.Sprintf("http://%s:%d", hostnameRunningComplement, port), func() {
 		srv.Close()
 		lastTestName = ""
 	}

--- a/internal/deploy/mitm.go
+++ b/internal/deploy/mitm.go
@@ -49,16 +49,6 @@ func (m *MITMClient) Configure(t *testing.T) *MITMConfiguration {
 	}
 }
 
-// WithMITMOptions changes the options of mitmproxy and executes inner() whilst those options are in effect.
-// As the options on mitmproxy are a shared resource, this function has transaction-like semantics, ensuring
-// the lock is released when inner() returns. This is similar to the `with` keyword in python.
-func (m *MITMClient) WithMITMOptions(t *testing.T, options map[string]any, inner func()) {
-	t.Helper()
-	lockID := m.lockOptions(t, options)
-	defer m.unlockOptions(t, lockID)
-	inner()
-}
-
 func (m *MITMClient) lockOptions(t *testing.T, options map[string]any) (lockID []byte) {
 	jsonBody, err := json.Marshal(map[string]interface{}{
 		"options": options,

--- a/internal/deploy/mitm.go
+++ b/internal/deploy/mitm.go
@@ -6,14 +6,22 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/must"
 )
 
 // must match the value in tests/addons/__init__.py
 const magicMITMURL = "http://mitm.code"
+
+var (
+	boolTrue  = true
+	boolFalse = false
+)
 
 type MITMClient struct {
 	client                    *http.Client
@@ -32,40 +40,26 @@ func NewMITMClient(proxyURL *url.URL, hostnameRunningComplement string) *MITMCli
 	}
 }
 
-func (m *MITMClient) WithSniffedEndpoint(t *testing.T, partialPath string, onSniff func(CallbackData), inner func()) {
-	t.Helper()
-	callbackURL, closeCallbackServer := NewCallbackServer(t, m.hostnameRunningComplement, onSniff)
-	defer closeCallbackServer()
-	m.WithMITMOptions(t, map[string]interface{}{
-		"callback": map[string]interface{}{
-			"callback_url": callbackURL,
-			// the filter is a python regexp
-			// "Regexes are Python-style" - https://docs.mitmproxy.org/stable/concepts-filters/
-			// re.escape() escapes very little:
-			// "Changed in version 3.7: Only characters that can have special meaning in a regular expression are escaped.
-			// As a result, '!', '"', '%', "'", ',', '/', ':', ';', '<', '=', '>', '@', and "`" are no longer escaped."
-			// https://docs.python.org/3/library/re.html#re.escape
-			//
-			// The majority of HTTP paths are just /foo/bar with % for path-encoding e.g @foo:bar=>%40foo%3Abar,
-			// so on balance we can probably just use the path directly.
-			"filter": "~u .*" + partialPath + ".*",
-		},
-	}, func() {
-		inner()
-	})
+func (m *MITMClient) Configure(t *testing.T) *MITMConfiguration {
+	return &MITMConfiguration{
+		t:        t,
+		pathCfgs: make(map[string]*MITMPathConfiguration),
+		mu:       &sync.Mutex{},
+		client:   m,
+	}
 }
 
 // WithMITMOptions changes the options of mitmproxy and executes inner() whilst those options are in effect.
 // As the options on mitmproxy are a shared resource, this function has transaction-like semantics, ensuring
 // the lock is released when inner() returns. This is similar to the `with` keyword in python.
-func (m *MITMClient) WithMITMOptions(t *testing.T, options map[string]interface{}, inner func()) {
+func (m *MITMClient) WithMITMOptions(t *testing.T, options map[string]any, inner func()) {
 	t.Helper()
 	lockID := m.lockOptions(t, options)
 	defer m.unlockOptions(t, lockID)
 	inner()
 }
 
-func (m *MITMClient) lockOptions(t *testing.T, options map[string]interface{}) (lockID []byte) {
+func (m *MITMClient) lockOptions(t *testing.T, options map[string]any) (lockID []byte) {
 	jsonBody, err := json.Marshal(map[string]interface{}{
 		"options": options,
 	})
@@ -91,4 +85,143 @@ func (m *MITMClient) unlockOptions(t *testing.T, lockID []byte) {
 	res, err := m.client.Do(req)
 	must.NotError(t, "failed to do request", err)
 	must.Equal(t, res.StatusCode, 200, "controller returned wrong HTTP status")
+}
+
+// MITMConfiguration represent a single mitmproxy configuration, with all options specified.
+//
+// Tests will typically build up this configuration by calling `Intercept` with the paths
+// they are interested in.
+type MITMConfiguration struct {
+	t        *testing.T
+	pathCfgs map[string]*MITMPathConfiguration
+	mu       *sync.Mutex
+	client   *MITMClient
+}
+
+func (c *MITMConfiguration) ForPath(partialPath string) *MITMPathConfiguration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	p, ok := c.pathCfgs[partialPath]
+	if ok {
+		return p
+	}
+	p = &MITMPathConfiguration{
+		t:    c.t,
+		path: partialPath,
+	}
+	c.pathCfgs[partialPath] = p
+	return p
+}
+
+// Execute a mitm proxy configuration for the duration of `inner`.
+func (c *MITMConfiguration) Execute(inner func()) {
+	// The HTTP request to mitmproxy needs to look like:
+	//   {
+	//     $addon_name: {
+	//       $addon_values...
+	//     }
+	//   }
+	// We have 2 add-ons: "callback" and "status_code". The former just sniffs
+	// requests/responses. The latter modifies the request/response in some way.
+	//
+	// The API shape of the add-ons are located inside the python files in tests/mitmproxy_addons
+	body := map[string]any{}
+	if len(c.pathCfgs) > 1 {
+		c.t.Fatalf(">1 path config currently unsupported") // TODO
+	}
+	c.mu.Lock()
+	for _, pathConfig := range c.pathCfgs {
+		if pathConfig.listener != nil {
+			callbackURL, closeCallbackServer := NewCallbackServer(c.t, c.client.hostnameRunningComplement, pathConfig.listener)
+			defer closeCallbackServer()
+
+			body["callback"] = map[string]any{
+				"callback_url": callbackURL,
+				"filter":       pathConfig.filter(),
+			}
+		}
+		if pathConfig.blockRequest != nil {
+			body["statuscode"] = map[string]any{
+				"return_status": pathConfig.blockStatusCode,
+				"block_request": *pathConfig.blockRequest,
+				"count":         pathConfig.blockCount,
+				"filter":        pathConfig.filter(),
+			}
+		}
+	}
+	c.mu.Unlock()
+
+	lockID := c.client.lockOptions(c.t, body)
+	defer c.client.unlockOptions(c.t, lockID)
+	inner()
+
+}
+
+type MITMPathConfiguration struct {
+	t           *testing.T
+	path        string
+	accessToken string
+	method      string
+	listener    func(cd CallbackData)
+
+	blockCount      int
+	blockStatusCode int
+	blockRequest    *bool // nil means don't block
+}
+
+func (p *MITMPathConfiguration) filter() string {
+	// the filter is a python regexp
+	// "Regexes are Python-style" - https://docs.mitmproxy.org/stable/concepts-filters/
+	// re.escape() escapes very little:
+	// "Changed in version 3.7: Only characters that can have special meaning in a regular expression are escaped.
+	// As a result, '!', '"', '%', "'", ',', '/', ':', ';', '<', '=', '>', '@', and "`" are no longer escaped."
+	// https://docs.python.org/3/library/re.html#re.escape
+	//
+	// The majority of HTTP paths are just /foo/bar with % for path-encoding e.g @foo:bar=>%40foo%3Abar,
+	// so on balance we can probably just use the path directly.
+	var s strings.Builder
+	s.WriteString("~u .*" + p.path + ".*")
+	if p.method != "" {
+		s.WriteString(" ~m " + strings.ToUpper(p.method))
+	}
+	if p.accessToken != "" {
+		s.WriteString(" ~hq " + p.accessToken)
+	}
+	return s.String()
+}
+
+func (p *MITMPathConfiguration) Listen(cb func(cd CallbackData)) *MITMPathConfiguration {
+	p.listener = cb
+	return p
+}
+
+func (p *MITMPathConfiguration) AccessToken(accessToken string) *MITMPathConfiguration {
+	p.accessToken = accessToken
+	return p
+}
+
+func (p *MITMPathConfiguration) Method(method string) *MITMPathConfiguration {
+	p.method = method
+	return p
+}
+
+func (p *MITMPathConfiguration) BlockRequest(count, returnStatusCode int) *MITMPathConfiguration {
+	if p.blockRequest != nil {
+		// we can't express blocking requests and responses separately, it doesn't make sense.
+		ct.Fatalf(p.t, "BlockRequest or BlockResponse cannot be called multiple times for the same path")
+	}
+	p.blockCount = count
+	p.blockRequest = &boolTrue
+	p.blockStatusCode = returnStatusCode
+	return p
+}
+
+func (p *MITMPathConfiguration) BlockResponse(count, returnStatusCode int) *MITMPathConfiguration {
+	if p.blockRequest != nil {
+		ct.Fatalf(p.t, "BlockRequest or BlockResponse cannot be called multiple times for the same path")
+	}
+	p.blockCount = count
+	p.blockRequest = &boolFalse
+	p.blockStatusCode = returnStatusCode
+	return p
 }

--- a/internal/deploy/mitm.go
+++ b/internal/deploy/mitm.go
@@ -1,0 +1,94 @@
+package deploy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/matrix-org/complement/must"
+)
+
+// must match the value in tests/addons/__init__.py
+const magicMITMURL = "http://mitm.code"
+
+type MITMClient struct {
+	client                    *http.Client
+	hostnameRunningComplement string
+}
+
+func NewMITMClient(proxyURL *url.URL, hostnameRunningComplement string) *MITMClient {
+	return &MITMClient{
+		hostnameRunningComplement: hostnameRunningComplement,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				Proxy: http.ProxyURL(proxyURL),
+			},
+		},
+	}
+}
+
+func (m *MITMClient) WithSniffedEndpoint(t *testing.T, partialPath string, onSniff func(CallbackData), inner func()) {
+	t.Helper()
+	callbackURL, closeCallbackServer := NewCallbackServer(t, m.hostnameRunningComplement, onSniff)
+	defer closeCallbackServer()
+	m.WithMITMOptions(t, map[string]interface{}{
+		"callback": map[string]interface{}{
+			"callback_url": callbackURL,
+			// the filter is a python regexp
+			// "Regexes are Python-style" - https://docs.mitmproxy.org/stable/concepts-filters/
+			// re.escape() escapes very little:
+			// "Changed in version 3.7: Only characters that can have special meaning in a regular expression are escaped.
+			// As a result, '!', '"', '%', "'", ',', '/', ':', ';', '<', '=', '>', '@', and "`" are no longer escaped."
+			// https://docs.python.org/3/library/re.html#re.escape
+			//
+			// The majority of HTTP paths are just /foo/bar with % for path-encoding e.g @foo:bar=>%40foo%3Abar,
+			// so on balance we can probably just use the path directly.
+			"filter": "~u .*" + partialPath + ".*",
+		},
+	}, func() {
+		inner()
+	})
+}
+
+// WithMITMOptions changes the options of mitmproxy and executes inner() whilst those options are in effect.
+// As the options on mitmproxy are a shared resource, this function has transaction-like semantics, ensuring
+// the lock is released when inner() returns. This is similar to the `with` keyword in python.
+func (m *MITMClient) WithMITMOptions(t *testing.T, options map[string]interface{}, inner func()) {
+	t.Helper()
+	lockID := m.lockOptions(t, options)
+	defer m.unlockOptions(t, lockID)
+	inner()
+}
+
+func (m *MITMClient) lockOptions(t *testing.T, options map[string]interface{}) (lockID []byte) {
+	jsonBody, err := json.Marshal(map[string]interface{}{
+		"options": options,
+	})
+	t.Logf("lockOptions: %v", string(jsonBody))
+	must.NotError(t, "failed to marshal options", err)
+	u := magicMITMURL + "/options/lock"
+	req, err := http.NewRequest("POST", u, bytes.NewBuffer(jsonBody))
+	must.NotError(t, "failed to prepare request", err)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := m.client.Do(req)
+	must.NotError(t, "failed to POST "+u, err)
+	must.Equal(t, res.StatusCode, 200, "controller returned wrong HTTP status")
+	lockID, err = io.ReadAll(res.Body)
+	must.NotError(t, "failed to read response", err)
+	return lockID
+}
+
+func (m *MITMClient) unlockOptions(t *testing.T, lockID []byte) {
+	t.Logf("unlockOptions")
+	req, err := http.NewRequest("POST", magicMITMURL+"/options/unlock", bytes.NewBuffer(lockID))
+	must.NotError(t, "failed to prepare request", err)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := m.client.Do(req)
+	must.NotError(t, "failed to do request", err)
+	must.Equal(t, res.StatusCode, 200, "controller returned wrong HTTP status")
+}

--- a/tests/device_keys_test.go
+++ b/tests/device_keys_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,27 +22,14 @@ func TestFailedDeviceKeyDownloadRetries(t *testing.T) {
 		tc := Instance().CreateTestContext(t, clientType, clientType)
 
 		// Track whether we received any requests on /keys/query
-		queryReceived := false
-		callbackUrl, closeCallbackServer := deploy.NewCallbackServer(
-			t,
-			tc.Deployment.GetConfig().HostnameRunningComplement,
-			func(data deploy.CallbackData) { queryReceived = true },
-		)
-		defer closeCallbackServer()
+		var queryReceived atomic.Bool
 
 		// Given that the first 4 attempts to download device keys will fail
-		tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
-			"statuscode": map[string]interface{}{
-				"return_status": http.StatusGatewayTimeout,
-				"block_request": true,
-				"count":         4,
-				"filter":        "~u .*\\/keys\\/query.* ~m POST",
-			},
-			"callback": map[string]interface{}{
-				"callback_url": callbackUrl,
-				"filter":       "~u .*\\/keys\\/query.* ~m POST",
-			},
-		}, func() {
+		mitmConfiguration := tc.Deployment.MITM().Configure(t)
+		mitmConfiguration.ForPath("/keys/query").Method("POST").BlockRequest(4, http.StatusGatewayTimeout).Listen(func(data deploy.CallbackData) {
+			queryReceived.Store(true)
+		})
+		mitmConfiguration.Execute(func() {
 			// And Alice and Bob are in an encrypted room together
 			roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}))
 			tc.Bob.MustJoinRoom(t, roomID, []string{"hs1"})
@@ -61,6 +49,6 @@ func TestFailedDeviceKeyDownloadRetries(t *testing.T) {
 		})
 
 		// Sanity: we did receive some requests (which we initially blocked)
-		must.Equal(t, queryReceived, true, "No request to /keys/query was received!")
+		must.Equal(t, queryReceived.Load(), true, "No request to /keys/query was received!")
 	})
 }

--- a/tests/device_keys_test.go
+++ b/tests/device_keys_test.go
@@ -24,13 +24,13 @@ func TestFailedDeviceKeyDownloadRetries(t *testing.T) {
 		queryReceived := false
 		callbackUrl, closeCallbackServer := deploy.NewCallbackServer(
 			t,
-			tc.Deployment,
+			tc.Deployment.GetConfig().HostnameRunningComplement,
 			func(data deploy.CallbackData) { queryReceived = true },
 		)
 		defer closeCallbackServer()
 
 		// Given that the first 4 attempts to download device keys will fail
-		tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+		tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 			"statuscode": map[string]interface{}{
 				"return_status": http.StatusGatewayTimeout,
 				"block_request": true,

--- a/tests/notification_test.go
+++ b/tests/notification_test.go
@@ -567,7 +567,7 @@ func TestMultiprocessDupeOTKUpload(t *testing.T) {
 	// artificially slow down the HTTP responses, such that we will potentially have 2 in-flight /keys/upload requests
 	// at once. If the NSE and main apps are talking to each other, they should be using the same key ID + key.
 	// If not... well, that's a bug because then the client will forget one of these keys.
-	tc.Deployment.WithSniffedEndpoint(t, "/keys/upload", func(cd deploy.CallbackData) {
+	tc.Deployment.MITM().WithSniffedEndpoint(t, "/keys/upload", func(cd deploy.CallbackData) {
 		if cd.AccessToken != aliceAccessToken {
 			return // let bob upload OTKs
 		}

--- a/tests/notification_test.go
+++ b/tests/notification_test.go
@@ -567,7 +567,8 @@ func TestMultiprocessDupeOTKUpload(t *testing.T) {
 	// artificially slow down the HTTP responses, such that we will potentially have 2 in-flight /keys/upload requests
 	// at once. If the NSE and main apps are talking to each other, they should be using the same key ID + key.
 	// If not... well, that's a bug because then the client will forget one of these keys.
-	tc.Deployment.MITM().WithSniffedEndpoint(t, "/keys/upload", func(cd deploy.CallbackData) {
+	mitmConfiguration := tc.Deployment.MITM().Configure(t)
+	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd deploy.CallbackData) {
 		if cd.AccessToken != aliceAccessToken {
 			return // let bob upload OTKs
 		}
@@ -580,7 +581,8 @@ func TestMultiprocessDupeOTKUpload(t *testing.T) {
 		// tarpit the response
 		t.Logf("tarpitting keys/upload response for 4 seconds")
 		time.Sleep(4 * time.Second)
-	}, func() {
+	})
+	mitmConfiguration.Execute(func() {
 		var eventID string
 		// Bob appears and sends a message, causing Bob to claim one of Alice's OTKs.
 		// The main app will see this in /sync and then try to upload another OTK, which we will tarpit.

--- a/tests/one_time_keys_test.go
+++ b/tests/one_time_keys_test.go
@@ -108,7 +108,7 @@ func TestFallbackKeyIsUsedIfOneTimeKeysRunOut(t *testing.T) {
 			var roomID string
 			var waiter api.Waiter
 			// Block all /keys/upload requests for Alice
-			tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+			tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 				"statuscode": map[string]interface{}{
 					"return_status": http.StatusGatewayTimeout,
 					"block_request": true,
@@ -160,7 +160,7 @@ func TestFailedOneTimeKeyUploadRetries(t *testing.T) {
 		// make a room so we can kick clients
 		roomID := tc.Alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 		// block /keys/upload and make a client
-		tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+		tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 			"statuscode": map[string]interface{}{
 				"return_status": http.StatusGatewayTimeout,
 				"block_request": true,
@@ -210,7 +210,7 @@ func TestFailedKeysClaimRetries(t *testing.T) {
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.Client) {
 			var stopPoking atomic.Bool
 			waiter := helpers.NewWaiter()
-			callbackURL, close := deploy.NewCallbackServer(t, tc.Deployment, func(cd deploy.CallbackData) {
+			callbackURL, close := deploy.NewCallbackServer(t, tc.Deployment.GetConfig().HostnameRunningComplement, func(cd deploy.CallbackData) {
 				t.Logf("%+v", cd)
 				if cd.ResponseCode == 200 {
 					waiter.Finish()
@@ -222,7 +222,7 @@ func TestFailedKeysClaimRetries(t *testing.T) {
 			// make a room which will link the 2 users together when
 			roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
 			// block /keys/claim and join the room, causing the Olm session to be created
-			tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+			tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 				"statuscode": map[string]interface{}{
 					"return_status": http.StatusGatewayTimeout,
 					"block_request": true,

--- a/tests/one_time_keys_test.go
+++ b/tests/one_time_keys_test.go
@@ -108,13 +108,9 @@ func TestFallbackKeyIsUsedIfOneTimeKeysRunOut(t *testing.T) {
 			var roomID string
 			var waiter api.Waiter
 			// Block all /keys/upload requests for Alice
-			tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
-				"statuscode": map[string]interface{}{
-					"return_status": http.StatusGatewayTimeout,
-					"block_request": true,
-					"filter":        "~u .*/keys/upload.* ~hq " + alice.CurrentAccessToken(t),
-				},
-			}, func() {
+			mitmConfiguration := tc.Deployment.MITM().Configure(t)
+			mitmConfiguration.ForPath("/keys/upload").AccessToken(alice.CurrentAccessToken(t)).BlockRequest(0, http.StatusGatewayTimeout)
+			mitmConfiguration.Execute(func() {
 				// claim all OTKs
 				mustClaimOTKs(t, otkGobbler, tc.Alice, int(otkCount))
 
@@ -160,14 +156,9 @@ func TestFailedOneTimeKeyUploadRetries(t *testing.T) {
 		// make a room so we can kick clients
 		roomID := tc.Alice.MustCreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 		// block /keys/upload and make a client
-		tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
-			"statuscode": map[string]interface{}{
-				"return_status": http.StatusGatewayTimeout,
-				"block_request": true,
-				"count":         2, // block it twice.
-				"filter":        "~u .*\\/keys\\/upload.* ~m POST",
-			},
-		}, func() {
+		mitmConfiguration := tc.Deployment.MITM().Configure(t)
+		mitmConfiguration.ForPath("/keys/upload").Method("POST").BlockRequest(2, http.StatusGatewayTimeout)
+		mitmConfiguration.Execute(func() {
 			tc.WithAliceSyncing(t, func(alice api.Client) {
 				tc.Bob.MustDo(t, "POST", []string{
 					"_matrix", "client", "v3", "keys", "claim",
@@ -210,30 +201,18 @@ func TestFailedKeysClaimRetries(t *testing.T) {
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.Client) {
 			var stopPoking atomic.Bool
 			waiter := helpers.NewWaiter()
-			callbackURL, close := deploy.NewCallbackServer(t, tc.Deployment.GetConfig().HostnameRunningComplement, func(cd deploy.CallbackData) {
+			// make a room which will link the 2 users together when
+			roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
+			// block /keys/claim and join the room, causing the Olm session to be created
+			mitmConfiguration := tc.Deployment.MITM().Configure(t)
+			mitmConfiguration.ForPath("/keys/claim").Method("POST").BlockRequest(2, http.StatusGatewayTimeout).Listen(func(cd deploy.CallbackData) {
 				t.Logf("%+v", cd)
 				if cd.ResponseCode == 200 {
 					waiter.Finish()
 					stopPoking.Store(true)
 				}
 			})
-			defer close()
-
-			// make a room which will link the 2 users together when
-			roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
-			// block /keys/claim and join the room, causing the Olm session to be created
-			tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
-				"statuscode": map[string]interface{}{
-					"return_status": http.StatusGatewayTimeout,
-					"block_request": true,
-					"count":         2, // block it twice.
-					"filter":        "~u .*\\/keys\\/claim.* ~m POST",
-				},
-				"callback": map[string]interface{}{
-					"callback_url": callbackURL,
-					"filter":       "~u .*\\/keys\\/claim.* ~m POST",
-				},
-			}, func() {
+			mitmConfiguration.Execute(func() {
 				// join the room. This should cause an Olm session to be made but it will fail as we cannot
 				// call /keys/claim. We should retry though.
 				tc.Bob.MustJoinRoom(t, roomID, []string{clientType.HS})

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func sniffToDeviceEvent(t *testing.T, d complement.Deployment, ch chan deploy.CallbackData) (callbackURL string, close func()) {
-	callbackURL, close = deploy.NewCallbackServer(t, d, func(cd deploy.CallbackData) {
+	callbackURL, close = deploy.NewCallbackServer(t, d.GetConfig().HostnameRunningComplement, func(cd deploy.CallbackData) {
 		if cd.Method == "OPTIONS" {
 			return // ignore CORS
 		}
@@ -69,7 +69,7 @@ func TestRoomKeyIsCycledOnDeviceLogout(t *testing.T) {
 			// we don't know when the new room key will be sent, it could be sent as soon as the device list update
 			// is sent, or it could be delayed until message send. We want to handle both cases so we start sniffing
 			// traffic now.
-			tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+			tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 				"callback": map[string]interface{}{
 					"callback_url": callbackURL,
 					"filter":       "~u .*\\/sendToDevice.*",
@@ -137,7 +137,7 @@ func TestRoomKeyIsCycledAfterEnoughMessages(t *testing.T) {
 			ch := make(chan deploy.CallbackData, 10)
 			callbackURL, close := sniffToDeviceEvent(t, tc.Deployment, ch)
 			defer close()
-			tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+			tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 				"callback": map[string]interface{}{
 					"callback_url": callbackURL,
 					"filter":       "~u .*\\/sendToDevice.*",
@@ -223,7 +223,7 @@ func TestRoomKeyIsCycledAfterEnoughTime(t *testing.T) {
 			ch := make(chan deploy.CallbackData, 10)
 			callbackURL, close := sniffToDeviceEvent(t, tc.Deployment, ch)
 			defer close()
-			tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+			tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 				"callback": map[string]interface{}{
 					"callback_url": callbackURL,
 					"filter":       "~u .*\\/sendToDevice.*",
@@ -288,7 +288,7 @@ func TestRoomKeyIsCycledOnMemberLeaving(t *testing.T) {
 			// we don't know when the new room key will be sent, it could be sent as soon as the device list update
 			// is sent, or it could be delayed until message send. We want to handle both cases so we start sniffing
 			// traffic now.
-			tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+			tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 				"callback": map[string]interface{}{
 					"callback_url": callbackURL,
 					"filter":       "~u .*\\/sendToDevice.*",
@@ -347,7 +347,7 @@ func TestRoomKeyIsNotCycled(t *testing.T) {
 				// we don't know when the new room key will be sent, it could be sent as soon as the device list update
 				// is sent, or it could be delayed until message send. We want to handle both cases so we start sniffing
 				// traffic now.
-				tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+				tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 					"callback": map[string]interface{}{
 						"callback_url": callbackURL,
 						"filter":       "~u .*\\/sendToDevice.*",
@@ -385,7 +385,7 @@ func TestRoomKeyIsNotCycled(t *testing.T) {
 				// we don't know when the new room key will be sent, it could be sent as soon as the device list update
 				// is sent, or it could be delayed until message send. We want to handle both cases so we start sniffing
 				// traffic now.
-				tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+				tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 					"callback": map[string]interface{}{
 						"callback_url": callbackURL,
 						"filter":       "~u .*\\/sendToDevice.*",
@@ -503,7 +503,7 @@ func testRoomKeyIsNotCycledOnClientRestartRust(t *testing.T, clientType api.Clie
 		callbackURL, close := sniffToDeviceEvent(t, tc.Deployment, ch)
 		defer close()
 
-		tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+		tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 			"callback": map[string]interface{}{
 				"callback_url": callbackURL,
 				"filter":       "~u .*\\/sendToDevice.*",
@@ -574,7 +574,7 @@ func testRoomKeyIsNotCycledOnClientRestartJS(t *testing.T, clientType api.Client
 		defer close()
 
 		// we want to start sniffing for the to-device event just before we restart the client.
-		tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+		tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 			"callback": map[string]interface{}{
 				"callback_url": callbackURL,
 				"filter":       "~u .*\\/sendToDevice.*",

--- a/tests/state_synchronisation_test.go
+++ b/tests/state_synchronisation_test.go
@@ -36,7 +36,7 @@ func testSigkillBeforeKeysUploadResponseRust(t *testing.T, clientType api.Client
 	var terminateClient func()
 	seenSecondKeysUploadWaiter := helpers.NewWaiter()
 	tc := Instance().CreateTestContext(t, clientType, clientType)
-	callbackURL, close := deploy.NewCallbackServer(t, tc.Deployment, func(cd deploy.CallbackData) {
+	callbackURL, close := deploy.NewCallbackServer(t, tc.Deployment.GetConfig().HostnameRunningComplement, func(cd deploy.CallbackData) {
 		if terminated.Load() {
 			// make sure the 2nd upload 200 OKs
 			if cd.ResponseCode != 200 {
@@ -53,7 +53,7 @@ func testSigkillBeforeKeysUploadResponseRust(t *testing.T, clientType api.Client
 	})
 	defer close()
 
-	tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+	tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 		"callback": map[string]interface{}{
 			"callback_url": callbackURL,
 			"filter":       "~u .*\\/keys\\/upload.*",
@@ -102,7 +102,7 @@ func testSigkillBeforeKeysUploadResponseJS(t *testing.T, clientType api.ClientTy
 	var terminateClient func()
 	seenSecondKeysUploadWaiter := helpers.NewWaiter()
 	tc := Instance().CreateTestContext(t, clientType, clientType)
-	callbackURL, close := deploy.NewCallbackServer(t, tc.Deployment, func(cd deploy.CallbackData) {
+	callbackURL, close := deploy.NewCallbackServer(t, tc.Deployment.GetConfig().HostnameRunningComplement, func(cd deploy.CallbackData) {
 		if cd.Method == "OPTIONS" {
 			return // ignore CORS
 		}
@@ -125,7 +125,7 @@ func testSigkillBeforeKeysUploadResponseJS(t *testing.T, clientType api.ClientTy
 	})
 	defer close()
 
-	tc.Deployment.WithMITMOptions(t, map[string]interface{}{
+	tc.Deployment.MITM().WithMITMOptions(t, map[string]interface{}{
 		"callback": map[string]interface{}{
 			"callback_url": callbackURL,
 			"filter":       "~u .*\\/keys\\/upload.*",


### PR DESCRIPTION
It's slightly better but not perfect yet because:
 - you can't enable both blocking and callbacks, then drop the blocking but not the callbacks. `TestToDeviceMessagesAreProcessedInOrder` needs this to block `/sync` for a while then unblock it, and throughout it wants to listen for /sync responses.
 - You can't listen for >1 path with a `MITMConfiguration`. We don't have any tests which want this currently though.
 - You can't do funky logic to determine if you should block a request (e.g only block if the request has these fields set). Again, no tests need this currently.