### PR TITLE
Upload mitmdump files as artifacts

### DIFF
--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -183,7 +183,7 @@ jobs:
           env:
             COMPLEMENT_BASE_IMAGE: homeserver
             COMPLEMENT_ENABLE_DIRTY_RUNS: 1
-            COMPLEMENT_CRYPTO_WRITE_CONTAINER_LOGS: 1
+            COMPLEMENT_CRYPTO_MITMDUMP: mitm.dump
             COMPLEMENT_CRYPTO_TEST_CLIENT_MATRIX: ${{ inputs.use_js_sdk != '' && 'jj' || 'rr' }} # TODO: brittle, we don't check rust-sdk input
             COMPLEMENT_SHARE_ENV_PREFIX: PASS_
             PASS_SYNAPSE_COMPLEMENT_DATABASE: sqlite
@@ -192,10 +192,11 @@ jobs:
             RUST_SDK_LIB_RELATIVE: ${{ inputs.use_rust_sdk == '.' &&  '/target/debug' || '/complement-crypto/rust-sdk/target/debug'}}
 
         - name: Upload logs
-          uses: actions/upload-artifact@v2
+          uses: actions/upload-artifact@v4
           if: ${{ failure() }}
           with:
-            name: Logs - ${{ job.status }}
+            name: Logs - ${{ inputs.use_js_sdk != '' && 'jssdk' || 'rust'}}
             path: |
               ./complement-crypto/tests/logs/*
+              ./complement-crypto/tests/mitm.dump
 

--- a/tests/membership_acls_test.go
+++ b/tests/membership_acls_test.go
@@ -194,7 +194,7 @@ func TestOnRejoinBobCanSeeButNotDecryptHistoryInPublicRoom(t *testing.T) {
 			bob.MustBackpaginate(t, roomID, 5)
 			// TODO: jJ runs fail as the timeline omits the event e.g it has leave,join and not leave,msg,join.
 			ev := bob.MustGetEvent(t, roomID, evID)
-			must.NotEqual(t, ev.Text, onlyAliceBody, "bob was able to decrypt a message from before he was joined")
+			must.Equal(t, ev.Text, onlyAliceBody, "bob was able to decrypt a message from before he was joined")
 			must.Equal(t, ev.FailedToDecrypt, true, "message not marked as failed to decrypt")
 
 			/* TODO: needs client changes

--- a/tests/membership_acls_test.go
+++ b/tests/membership_acls_test.go
@@ -194,7 +194,7 @@ func TestOnRejoinBobCanSeeButNotDecryptHistoryInPublicRoom(t *testing.T) {
 			bob.MustBackpaginate(t, roomID, 5)
 			// TODO: jJ runs fail as the timeline omits the event e.g it has leave,join and not leave,msg,join.
 			ev := bob.MustGetEvent(t, roomID, evID)
-			must.Equal(t, ev.Text, onlyAliceBody, "bob was able to decrypt a message from before he was joined")
+			must.NotEqual(t, ev.Text, onlyAliceBody, "bob was able to decrypt a message from before he was joined")
 			must.Equal(t, ev.FailedToDecrypt, true, "message not marked as failed to decrypt")
 
 			/* TODO: needs client changes


### PR DESCRIPTION
This allows HTTP flows from CI runs to be viewed. Fixes #80.

Also changes the upload version to v4 because:
 - v2 is deprecated on June 30, 2024.
 - v4 has faster uploads
 - v4 artifacts are shown immediately in the web UI, whereas v2 needs the job to complete before showing.

However, v4 artifacts are immutable so we cannot upload artifacts with the same name. Instead, rename the artifact depending on the SDK tested.