### PR TITLE
Implement own user verification

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -61,6 +61,8 @@ type Client interface {
 	LoadBackup(t ct.TestLike, recoveryKey string) error
 	// GetNotification gets push notification-like information for the given event. If there is a problem, an error is returned.
 	GetNotification(t ct.TestLike, roomID, eventID string) (*Notification, error)
+	// RequestVerification learns about the available/supported protocols from other logged in sessions.
+	RequestVerification(t ct.TestLike, listener VerificationListener)
 	// Log something to stdout and the underlying client log file
 	Logf(t ct.TestLike, format string, args ...interface{})
 	// The user for this client
@@ -69,6 +71,29 @@ type Client interface {
 	CurrentAccessToken(t ct.TestLike) string
 	Type() ClientTypeLang
 	Opts() ClientCreationOpts
+}
+
+type VerificationState string
+
+const (
+	VerificationStateUnknown    VerificationState = "unknown"
+	VerificationStateUnverified VerificationState = "unverified"
+	VerificationStateVerified   VerificationState = "verified"
+)
+
+type VerificationData struct {
+	Emojis   []string
+	Decimals []uint16
+}
+
+type VerificationListener interface {
+	Close()
+	OnVerificationStateChange(vState VerificationState)
+	DidAcceptVerificationRequest()
+	DidReceiveVerificationData(vData VerificationData)
+	DidFail()
+	DidCancel()
+	DidFinish()
 }
 
 type Notification struct {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -61,8 +61,8 @@ type Client interface {
 	LoadBackup(t ct.TestLike, recoveryKey string) error
 	// GetNotification gets push notification-like information for the given event. If there is a problem, an error is returned.
 	GetNotification(t ct.TestLike, roomID, eventID string) (*Notification, error)
-	// RequestVerification learns about the available/supported protocols from other logged in sessions.
-	RequestVerification(t ct.TestLike, listener VerificationListener)
+	// RequestOwnUserVerification learns about the available/supported protocols from other logged in sessions.
+	RequestOwnUserVerification(t ct.TestLike, listener VerificationListener)
 	// Log something to stdout and the underlying client log file
 	Logf(t ct.TestLike, format string, args ...interface{})
 	// The user for this client

--- a/internal/api/js/js-sdk/index.html
+++ b/internal/api/js/js-sdk/index.html
@@ -7,6 +7,8 @@
     window.Buffer = Buffer;
     import { decodeRecoveryKey } from "matrix-js-sdk/src/crypto/recoverykey";
     window.decodeRecoveryKey = decodeRecoveryKey;
+    import { VerificationPhase } from "matrix-js-sdk/src/crypto-api/verification";
+    window.VerificationPhase = VerificationPhase;
     import * as sdk from "matrix-js-sdk";
     window.matrix = sdk;
     import { IndexedDBStore, IndexedDBCryptoStore } from "matrix-js-sdk/src/matrix";

--- a/internal/api/js/js-sdk/index.html
+++ b/internal/api/js/js-sdk/index.html
@@ -7,8 +7,11 @@
     window.Buffer = Buffer;
     import { decodeRecoveryKey } from "matrix-js-sdk/src/crypto/recoverykey";
     window.decodeRecoveryKey = decodeRecoveryKey;
-    import { VerificationPhase } from "matrix-js-sdk/src/crypto-api/verification";
+    import { VerificationPhase, VerifierEvent } from "matrix-js-sdk/src/crypto-api/verification";
     window.VerificationPhase = VerificationPhase;
+    window.VerifierEvent = VerifierEvent;
+    import { CryptoEvent } from "matrix-js-sdk/src/crypto";
+    window.CryptoEvent = CryptoEvent;
     import * as sdk from "matrix-js-sdk";
     window.matrix = sdk;
     import { IndexedDBStore, IndexedDBCryptoStore } from "matrix-js-sdk/src/matrix";

--- a/internal/api/js/js.go
+++ b/internal/api/js/js.go
@@ -414,7 +414,7 @@ func (c *JSClient) ListenForVerificationRequests(t ct.TestLike) chan api.Verific
 		}
 		switch msg.Stage {
 		case "VerificationRequestReceived":
-			ch <- api.NewVerificationStageRequestedRequetee(container)
+			ch <- api.NewVerificationStageRequestedReceiver(container)
 		case "Ready":
 			ch <- api.NewVerificationStageReady(container)
 		case "Started":

--- a/internal/api/js/js.go
+++ b/internal/api/js/js.go
@@ -261,6 +261,14 @@ func (c *JSClient) GetNotification(t ct.TestLike, roomID, eventID string) (*api.
 	return nil, fmt.Errorf("not implemented yet") // TODO
 }
 
+func (c *JSClient) RequestVerification(t ct.TestLike, listener api.VerificationListener) {
+	chrome.MustRunAsyncFn[chrome.Void](t, c.browser.Ctx, `
+	const req = await window.__client.getCrypto().requestOwnUserVerification();
+	req.on("change", () => {
+
+	})`)
+}
+
 func (c *JSClient) ForceClose(t ct.TestLike) {
 	t.Helper()
 	t.Logf("force closing a JS client is the same as a normal close (closing browser)")

--- a/internal/api/js/js.go
+++ b/internal/api/js/js.go
@@ -1,6 +1,7 @@
 package js
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -50,27 +51,33 @@ func writeToLog(s string, args ...interface{}) {
 }
 
 type JSClient struct {
-	browser     *chrome.Browser
-	listeners   map[int32]func(ctrlMsg *ControlMessage)
-	listenerID  atomic.Int32
-	listenersMu *sync.RWMutex
-	userID      string
-	opts        api.ClientCreationOpts
+	browser               *chrome.Browser
+	listeners             map[int32]func(ctrlMsg *ControlMessage)
+	listenerID            atomic.Int32
+	listenersMu           *sync.RWMutex
+	userID                string
+	opts                  api.ClientCreationOpts
+	verificationChannel   chan api.VerificationStage
+	verificationChannelMu *sync.Mutex
 }
 
 func NewJSClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, error) {
 	jsc := &JSClient{
-		listeners:   make(map[int32]func(ctrlMsg *ControlMessage)),
-		userID:      opts.UserID,
-		listenersMu: &sync.RWMutex{},
-		opts:        opts,
+		listeners:             make(map[int32]func(ctrlMsg *ControlMessage)),
+		userID:                opts.UserID,
+		listenersMu:           &sync.RWMutex{},
+		opts:                  opts,
+		verificationChannelMu: &sync.Mutex{},
 	}
 	portKey := opts.UserID + opts.DeviceID
 	browser, err := chrome.RunHeadless(func(s string) {
-		// TODO: debug mode only?
-		writeToLog("[%s,%s] console.log %s\n", jsc.browser.BaseURL, opts.UserID, s)
+		var baseURL string
+		if jsc.browser != nil { // can be nil if we log immediately before RunHeadless returns
+			baseURL = jsc.browser.BaseURL
+		}
+		writeToLog("[%s,%s] console.log %s\n", baseURL, opts.UserID, s)
 
-		msg := unpackControlMessage(s)
+		msg := unpackControlMessage(t, s)
 		if msg == nil {
 			return
 		}
@@ -265,26 +272,178 @@ func (c *JSClient) GetNotification(t ct.TestLike, roomID, eventID string) (*api.
 	return nil, fmt.Errorf("not implemented yet") // TODO
 }
 
-func (c *JSClient) RequestOwnUserVerification(t ct.TestLike, listener api.VerificationListener) {
+func (c *JSClient) ensureListeningForVerificationRequests(t ct.TestLike) chan api.VerificationStage {
+	c.verificationChannelMu.Lock()
+	defer c.verificationChannelMu.Unlock()
+	if c.verificationChannel == nil {
+		// we need to support multiple transition stages firing at once
+		c.verificationChannel = make(chan api.VerificationStage, 4)
+		chrome.MustRunAsyncFn[chrome.Void](t, c.browser.Ctx, `
+	window.__client.on(CryptoEvent.VerificationRequestReceived, function(request) {
+		request.on("change", () => {
+			console.log("RequestOwnUserVerification got phase " + request.phase);
+			switch(request.phase) {
+				case VerificationPhase.Unsent:
+					console.log("Unsent");
+					break;
+				case VerificationPhase.Requested: // An m.key.verification.request event has been sent or received
+					console.log("Requested");
+					break;
+				case VerificationPhase.Ready: // An m.key.verification.ready event has been sent or received, indicating the verification request is accepted.
+					`+EmitControlMessageVerificationJS(
+			`"Ready"`,
+			"request.transactionId",
+			"request.otherUserId",
+			"request.otherDeviceId",
+			"{}",
+		)+`
+					break;
+				case VerificationPhase.Started: // In-flight verification. This means that an m.key.verification.start event has been sent or received, choosing a verification method; however the verification has not yet completed or been cancelled.
+					`+EmitControlMessageVerificationJS(
+			`"Started"`,
+			"request.transactionId",
+			"request.otherUserId",
+			"request.otherDeviceId",
+			"{}",
+		)+`
+					break;
+				case VerificationPhase.Cancelled: // An m.key.verification.cancel event has been sent or received at any time before the 'done' event, cancelling the verification request
+					`+EmitControlMessageVerificationJS(
+			`"Cancelled"`,
+			"request.transactionId",
+			"request.otherUserId",
+			"request.otherDeviceId",
+			"{}",
+		)+`
+					break;
+				case VerificationPhase.Done: // Normally this means that m.key.verification.done events have been sent and received.
+					`+EmitControlMessageVerificationJS(
+			`"Done"`,
+			"request.transactionId",
+			"request.otherUserId",
+			"request.otherDeviceId",
+			"{}",
+		)+`
+					break;
+			}
+		});
+		if (!window.__pendingVerificationByTxnID) {
+			window.__pendingVerificationByTxnID = {};
+		}
+		window.__pendingVerificationByTxnID[request.transactionId] = request;
+		`+EmitControlMessageVerificationJS(
+			`"VerificationRequestReceived"`,
+			"request.transactionId",
+			"request.otherUserId",
+			"request.otherDeviceId",
+			"{}",
+		)+`
+	});`)
+	}
+	return c.verificationChannel
+}
+
+func (c *JSClient) ListenForVerificationRequests(t ct.TestLike) chan api.VerificationStage {
+	ch := c.ensureListeningForVerificationRequests(t)
+	txnIDsStarted := make(map[string]bool)
+	c.listenForUpdates(func(ctrlMsg *ControlMessage) {
+		msg := ctrlMsg.AsControlMessageVerification()
+		if msg == nil {
+			return
+		}
+		container := &api.VerificationContainer{
+			Mutex: &sync.Mutex{},
+			VReq: api.VerificationRequest{
+				SenderUserID:     msg.UserID,
+				SenderDeviceID:   msg.DeviceID,
+				TxnID:            msg.TxnID,
+				ReceiverUserID:   c.userID,
+				ReceiverDeviceID: c.opts.DeviceID,
+			},
+			SendReady: func() {
+				chrome.MustRunAsyncFn[chrome.Void](t, c.browser.Ctx, `
+						await window.__pendingVerificationByTxnID["`+msg.TxnID+`"].accept();
+					`)
+			},
+			SendStart: func(method string) {
+				chrome.MustRunAsyncFn[chrome.Void](t, c.browser.Ctx, `
+						const verifier = await window.__pendingVerificationByTxnID["`+msg.TxnID+`"].startVerification("`+method+`");
+					`)
+			},
+			SendTransition: func() {
+				chrome.MustRunAsyncFn[chrome.Void](t, c.browser.Ctx, `
+					const request = window.__pendingVerificationByTxnID["`+msg.TxnID+`"];
+					const verifier = request.verifier;
+					verifier.on(VerifierEvent.ShowSas, (sas) => {
+						`+EmitControlMessageVerificationJS(
+					`"TransitionSAS"`,
+					"request.transactionId",
+					"request.otherUserId",
+					"request.otherDeviceId",
+					"sas.sas",
+				)+`
+					});
+					// don't await on this as it blocks until the verification has completed/cancelled.
+					verifier.verify();
+				`)
+			},
+			SendCancel: func() {
+				chrome.MustRunAsyncFn[chrome.Void](t, c.browser.Ctx, `
+						await window.__pendingVerificationByTxnID["`+msg.TxnID+`"].cancel();
+					`)
+			},
+		}
+		switch msg.Stage {
+		case "VerificationRequestReceived":
+			ch <- api.NewVerificationStageRequestedRequetee(container)
+		case "Ready":
+			ch <- api.NewVerificationStageReady(container)
+		case "Started":
+			// we will get many "VerificationPhase.Started" calls as we do SAS events. We don't want
+			// to call SendTransition many times, so only emit this once.
+			if txnIDsStarted[msg.TxnID] {
+				return
+			}
+			txnIDsStarted[msg.TxnID] = true
+			ch <- api.NewVerificationStageStart(container)
+		case "TransitionSAS":
+			verificationData := struct {
+				Decimal []uint16    `json:"decimal"`
+				Emoji   [][2]string `json:"emoji"` // tuple `[emoji, name]`
+			}{}
+			if err := json.Unmarshal([]byte(msg.Data), &verificationData); err != nil {
+				ct.Errorf(t, "failed to unmarshal verification data: %s", err)
+			}
+			if len(verificationData.Decimal) > 0 || len(verificationData.Emoji) > 0 {
+				var emoji []string
+				for _, e := range verificationData.Emoji {
+					emoji = append(emoji, e[0])
+				}
+				container.VData = api.VerificationData{
+					Decimals: verificationData.Decimal,
+					Emojis:   emoji,
+				}
+				ch <- api.NewVerificationStageTransitioned(container)
+			} else {
+				t.Logf("WARN: Got TransitionSAS but no emoji/decimal")
+			}
+		case "Cancelled":
+			ch <- api.NewVerificationStageCancelled(container)
+		case "Done":
+			ch <- api.NewVerificationStageDone(container)
+		}
+	})
+	return ch
+}
+
+func (c *JSClient) RequestOwnUserVerification(t ct.TestLike) chan api.VerificationStage {
+	ch := c.ensureListeningForVerificationRequests(t)
 	chrome.MustRunAsyncFn[chrome.Void](t, c.browser.Ctx, `
 	const req = await window.__client.getCrypto().requestOwnUserVerification();
-	req.on("change", () => {
-		console.log("RequestOwnUserVerification got phase " + req.phase());
-		switch(req.phase()) {
-			case VerificationPhase.Unsent:
-				break;
-			case VerificationPhase.Requested: // An m.key.verification.request event has been sent or received
-				break;
-			case VerificationPhase.Ready: // An m.key.verification.ready event has been sent or received, indicating the verification request is accepted.
-				break;
-			case VerificationPhase.Started: // In-flight verification. This means that an m.key.verification.start event has been sent or received, choosing a verification method; however the verification has not yet completed or been cancelled.
-				break;
-			case VerificationPhase.Cancelled: // An m.key.verification.cancel event has been sent or received at any time before the 'done' event, cancelling the verification request
-				break;
-			case VerificationPhase.Done: // Normally this means that m.key.verification.done events have been sent and received.
-				break;
-		}
-	})`)
+	// emit a receive request to reuse code paths for incoming verification requests.
+	window.__client.emit(CryptoEvent.VerificationRequestReceived, req);
+`)
+	return ch
 }
 
 func (c *JSClient) ForceClose(t ct.TestLike) {

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -197,7 +197,7 @@ func (c *RustClient) CurrentAccessToken(t ct.TestLike) string {
 	return s.AccessToken
 }
 
-func (c *RustClient) RequestVerification(t ct.TestLike, listener api.VerificationListener) {
+func (c *RustClient) RequestOwnUserVerification(t ct.TestLike, listener api.VerificationListener) {
 	svc, err := c.FFIClient.GetSessionVerificationController()
 	if err != nil {
 		ct.Fatalf(t, "GetSessionVerificationController: %s", err)

--- a/internal/api/verification.go
+++ b/internal/api/verification.go
@@ -79,7 +79,7 @@ type VerificationStageEnum int
 
 const (
 	VerificationStageEnumRequested VerificationStageEnum = iota
-	VerificationStageEnumRequestedRequetee
+	VerificationStageEnumRequestedReceiver
 	VerificationStageEnumReady
 	VerificationStageEnumStart
 	VerificationStageEnumTransitioned
@@ -110,21 +110,21 @@ type VerificationStageRequestedReceiver interface {
 	Cancel()
 	Ready()
 }
-type verificationStageRequestedRequetee struct {
+type verificationStageRequestedReceiver struct {
 	c *VerificationContainer
 }
 
-func (v *verificationStageRequestedRequetee) Request() VerificationRequest {
+func (v *verificationStageRequestedReceiver) Request() VerificationRequest {
 	return v.c.VReq
 }
-func (v *verificationStageRequestedRequetee) Cancel() {
+func (v *verificationStageRequestedReceiver) Cancel() {
 	v.c.SendCancel()
 }
-func (v *verificationStageRequestedRequetee) Ready() {
+func (v *verificationStageRequestedReceiver) Ready() {
 	v.c.SendReady()
 }
-func NewVerificationStageRequestedRequetee(c *VerificationContainer) VerificationStageRequestedReceiver {
-	return &verificationStageRequestedRequetee{c}
+func NewVerificationStageRequestedReceiver(c *VerificationContainer) VerificationStageRequestedReceiver {
+	return &verificationStageRequestedReceiver{c}
 }
 
 type VerificationStageReady interface {
@@ -254,8 +254,8 @@ func (c *VerificationContainer) Stage(stageEnum VerificationStageEnum) Verificat
 	switch stageEnum {
 	case VerificationStageEnumRequested:
 		return NewVerificationStageRequested(c)
-	case VerificationStageEnumRequestedRequetee:
-		return NewVerificationStageRequestedRequetee(c)
+	case VerificationStageEnumRequestedReceiver:
+		return NewVerificationStageRequestedReceiver(c)
 	case VerificationStageEnumReady:
 		return NewVerificationStageReady(c)
 	case VerificationStageEnumStart:

--- a/internal/api/verification.go
+++ b/internal/api/verification.go
@@ -1,0 +1,262 @@
+package api
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Verification Stage Machine (all stages can transition to Cancelled (m.key.verification.cancel))
+//        +-----------+
+//  ----> | Requested |  <-- m.key.verification.request has been sent/received
+//        +-----------+
+//             |
+//        +----v------+
+//        |   Ready   |  <--- m.key.verification.ready has been sent/received
+//        +-----------+
+//             |
+//        +----v------+
+//        |   Start   |  <---  m.key.verification.start has been sent/received
+//        +-----------+
+//             |
+//        +----v---------+
+//    .---| Transitioned | <-- Verification specific, SAS/QR code logic in this stage. Can fire multiple times.
+//     `->+--------------+
+//             |
+//        +----v----+
+//        |   Done  |  <--- m.key.verification.done has been sent/received
+//        +---------+
+//
+
+// For SAS Verification, clients may not expose all of the following stages.
+// The Transitioned stages are outlined in
+// https://spec.matrix.org/v1.11/client-server-api/#short-authentication-string-sas-verification :
+//        ┌───────┐
+//        │Created│
+//        └───┬───┘
+//            │
+//        ┌───⌄───┐
+//        │Started│
+//        └───┬───┘
+//            │
+//       ┌────⌄───┐
+//       │Accepted│
+//       └────┬───┘
+//            │
+//    ┌───────⌄──────┐
+//    │Keys Exchanged│ <-- this stage will always be exposed as the emoji are ready
+//    └───────┬──────┘
+//            │
+//    ________⌄________
+//   ╱                 ╲       ┌─────────┐
+//  ╱   Does the short  ╲______│Cancelled│
+//  ╲ auth string match ╱ no   └─────────┘
+//   ╲_________________╱
+//            │yes
+//            │
+//       ┌────⌄────┐
+//       │Confirmed│
+//       └────┬────┘
+//            │
+//        ┌───⌄───┐
+//        │  Done │
+//        └───────┘
+
+type VerificationData struct {
+	Emojis   []string
+	Decimals []uint16
+}
+
+type VerificationRequest struct {
+	TxnID            string
+	SenderUserID     string
+	SenderDeviceID   string
+	ReceiverUserID   string
+	ReceiverDeviceID string
+}
+
+type VerificationStage interface{}
+type VerificationStageEnum int
+
+const (
+	VerificationStageEnumRequested VerificationStageEnum = iota
+	VerificationStageEnumRequestedRequetee
+	VerificationStageEnumReady
+	VerificationStageEnumStart
+	VerificationStageEnumTransitioned
+	VerificationStageEnumDone
+	VerificationStageEnumCancelled
+)
+
+type VerificationStageRequested interface {
+	Request() VerificationRequest
+	Cancel()
+}
+type verificationStageRequested struct {
+	c *VerificationContainer
+}
+
+func (v *verificationStageRequested) Request() VerificationRequest {
+	return v.c.VReq
+}
+func (v *verificationStageRequested) Cancel() {
+	v.c.SendCancel()
+}
+func NewVerificationStageRequested(c *VerificationContainer) VerificationStageRequested {
+	return &verificationStageRequested{c}
+}
+
+type VerificationStageRequestedRequetee interface {
+	Request() VerificationRequest
+	Cancel()
+	Ready()
+}
+type verificationStageRequestedRequetee struct {
+	c *VerificationContainer
+}
+
+func (v *verificationStageRequestedRequetee) Request() VerificationRequest {
+	return v.c.VReq
+}
+func (v *verificationStageRequestedRequetee) Cancel() {
+	v.c.SendCancel()
+}
+func (v *verificationStageRequestedRequetee) Ready() {
+	v.c.SendReady()
+}
+func NewVerificationStageRequestedRequetee(c *VerificationContainer) VerificationStageRequestedRequetee {
+	return &verificationStageRequestedRequetee{c}
+}
+
+type VerificationStageReady interface {
+	Start(method string)
+	Cancel()
+}
+type verificationStageReady struct {
+	c *VerificationContainer
+}
+
+func (v *verificationStageReady) Start(method string) {
+	v.c.SendStart(method)
+}
+func (v *verificationStageReady) Cancel() {
+	v.c.SendCancel()
+}
+func NewVerificationStageReady(c *VerificationContainer) VerificationStageReady {
+	return &verificationStageReady{c}
+}
+
+type VerificationStageStart interface {
+	Transition()
+	Cancel()
+}
+type verificationStageStart struct {
+	c *VerificationContainer
+}
+
+func (v *verificationStageStart) Transition() {
+	v.c.SendTransition()
+}
+func (v *verificationStageStart) Cancel() {
+	v.c.SendCancel()
+}
+func NewVerificationStageStart(c *VerificationContainer) VerificationStageStart {
+	return &verificationStageStart{c}
+}
+
+type VerificationStageTransitioned interface {
+	Done()
+	VerificationData() VerificationData
+	Cancel()
+	Transition()
+}
+type verificationStageTransitioned struct {
+	c *VerificationContainer
+}
+
+func (v *verificationStageTransitioned) Done() {
+	v.c.SendDone()
+}
+func (v *verificationStageTransitioned) VerificationData() VerificationData {
+	return v.c.VData
+}
+func (v *verificationStageTransitioned) Cancel() {
+	v.c.SendCancel()
+}
+func (v *verificationStageTransitioned) Transition() {
+	v.c.SendTransition()
+}
+func NewVerificationStageTransitioned(c *VerificationContainer) VerificationStageTransitioned {
+	return &verificationStageTransitioned{c}
+}
+
+type VerificationStageDone interface {
+	VerificationState() VerificationState
+}
+type verificationStageDone struct {
+	c *VerificationContainer
+}
+
+func (v *verificationStageDone) VerificationState() VerificationState {
+	return v.c.VState
+}
+func NewVerificationStageDone(c *VerificationContainer) VerificationStageDone {
+	return &verificationStageDone{c}
+}
+
+type VerificationStageCancelled interface {
+}
+
+func NewVerificationStageCancelled(c *VerificationContainer) VerificationStageCancelled {
+	return struct{}{}
+}
+
+type VerificationState string
+
+var (
+	VerificationStateVerified   VerificationState = "verified"
+	VerificationStateUnverified VerificationState = "unverified"
+	VerificationStateUnknown    VerificationState = "unknown"
+)
+
+// VerificationContainer is a helper struct for client implementations.
+// It implements all verification stages, so can be returned at each stage.
+// The container is never exposed directly in tests, as interfaces hide
+// invalid state transitions.
+type VerificationContainer struct {
+	VReq           VerificationRequest
+	VData          VerificationData
+	VState         VerificationState
+	SendReady      func()
+	SendStart      func(method string)
+	SendCancel     func()
+	SendDone       func()
+	SendTransition func()
+	Mutex          *sync.Mutex
+}
+
+func (c *VerificationContainer) Modify(fn func(cc *VerificationContainer)) {
+	c.Mutex.Lock()
+	defer c.Mutex.Unlock()
+	fn(c)
+}
+
+func (c *VerificationContainer) Stage(stageEnum VerificationStageEnum) VerificationStage {
+	switch stageEnum {
+	case VerificationStageEnumRequested:
+		return NewVerificationStageRequested(c)
+	case VerificationStageEnumRequestedRequetee:
+		return NewVerificationStageRequestedRequetee(c)
+	case VerificationStageEnumReady:
+		return NewVerificationStageReady(c)
+	case VerificationStageEnumStart:
+		return NewVerificationStageStart(c)
+	case VerificationStageEnumTransitioned:
+		return NewVerificationStageTransitioned(c)
+	case VerificationStageEnumDone:
+		return NewVerificationStageDone(c)
+	case VerificationStageEnumCancelled:
+		return struct{}{}
+	default:
+		panic(fmt.Sprintf("unknown VerificationStageEnum: %v", stageEnum))
+	}
+}

--- a/internal/api/verification.go
+++ b/internal/api/verification.go
@@ -105,7 +105,7 @@ func NewVerificationStageRequested(c *VerificationContainer) VerificationStageRe
 	return &verificationStageRequested{c}
 }
 
-type VerificationStageRequestedRequetee interface {
+type VerificationStageRequestedReceiver interface {
 	Request() VerificationRequest
 	Cancel()
 	Ready()
@@ -123,7 +123,7 @@ func (v *verificationStageRequestedRequetee) Cancel() {
 func (v *verificationStageRequestedRequetee) Ready() {
 	v.c.SendReady()
 }
-func NewVerificationStageRequestedRequetee(c *VerificationContainer) VerificationStageRequestedRequetee {
+func NewVerificationStageRequestedRequetee(c *VerificationContainer) VerificationStageRequestedReceiver {
 	return &verificationStageRequestedRequetee{c}
 }
 
@@ -166,6 +166,8 @@ func NewVerificationStageStart(c *VerificationContainer) VerificationStageStart 
 type VerificationStageTransitioned interface {
 	Done()
 	VerificationData() VerificationData
+	Approve()
+	Decline()
 	Cancel()
 	Transition()
 }
@@ -184,6 +186,12 @@ func (v *verificationStageTransitioned) Cancel() {
 }
 func (v *verificationStageTransitioned) Transition() {
 	v.c.SendTransition()
+}
+func (v *verificationStageTransitioned) Approve() {
+	v.c.SendApprove()
+}
+func (v *verificationStageTransitioned) Decline() {
+	v.c.SendDecline()
 }
 func NewVerificationStageTransitioned(c *VerificationContainer) VerificationStageTransitioned {
 	return &verificationStageTransitioned{c}
@@ -231,6 +239,8 @@ type VerificationContainer struct {
 	SendCancel     func()
 	SendDone       func()
 	SendTransition func()
+	SendApprove    func()
+	SendDecline    func()
 	Mutex          *sync.Mutex
 }
 

--- a/internal/deploy/rpc_client.go
+++ b/internal/deploy/rpc_client.go
@@ -190,8 +190,8 @@ func (c *RPCClient) CurrentAccessToken(t ct.TestLike) string {
 	return token
 }
 
-func (c *RPCClient) RequestVerification(t ct.TestLike, listener api.VerificationListener) {
-
+func (c *RPCClient) RequestOwnUserVerification(t ct.TestLike, listener api.VerificationListener) {
+	panic("unimplemented")
 }
 
 // Remove any persistent storage, if it was enabled.

--- a/internal/deploy/rpc_client.go
+++ b/internal/deploy/rpc_client.go
@@ -190,6 +190,10 @@ func (c *RPCClient) CurrentAccessToken(t ct.TestLike) string {
 	return token
 }
 
+func (c *RPCClient) RequestVerification(t ct.TestLike, listener api.VerificationListener) {
+
+}
+
 // Remove any persistent storage, if it was enabled.
 func (c *RPCClient) DeletePersistentStorage(t ct.TestLike) {
 	var void int

--- a/internal/deploy/rpc_client.go
+++ b/internal/deploy/rpc_client.go
@@ -190,7 +190,11 @@ func (c *RPCClient) CurrentAccessToken(t ct.TestLike) string {
 	return token
 }
 
-func (c *RPCClient) RequestOwnUserVerification(t ct.TestLike, listener api.VerificationListener) {
+func (c *RPCClient) RequestOwnUserVerification(t ct.TestLike) chan api.VerificationStage {
+	panic("unimplemented")
+}
+
+func (c *RPCClient) ListenForVerificationRequests(t ct.TestLike) chan api.VerificationStage {
 	panic("unimplemented")
 }
 

--- a/tests/key_backup_test.go
+++ b/tests/key_backup_test.go
@@ -50,7 +50,10 @@ func TestCanBackupKeys(t *testing.T) {
 			// Now login on a new device
 			csapiAlice2 := tc.MustRegisterNewDevice(t, tc.Alice, "BACKUP_RESTORER")
 			backupRestorer := tc.MustLoginClient(t, &cc.ClientCreationRequest{
-				User: csapiAlice2,
+				User: &cc.User{
+					CSAPI:      csapiAlice2.CSAPI,
+					ClientType: clientTypeB,
+				},
 			})
 			defer backupRestorer.Close(t)
 
@@ -109,7 +112,10 @@ func TestBackupWrongRecoveryKeyFails(t *testing.T) {
 			// Now login on a new device
 			csapiAlice2 := tc.MustRegisterNewDevice(t, tc.Alice, "BACKUP_RESTORER")
 			backupRestorer := tc.MustLoginClient(t, &cc.ClientCreationRequest{
-				User: csapiAlice2,
+				User: &cc.User{
+					CSAPI:      csapiAlice2.CSAPI,
+					ClientType: clientTypeB,
+				},
 			})
 			defer backupRestorer.Close(t)
 

--- a/tests/verification_test.go
+++ b/tests/verification_test.go
@@ -1,0 +1,72 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/matrix-org/complement-crypto/internal/api"
+	"github.com/matrix-org/complement-crypto/internal/cc"
+)
+
+// happy case test of Alice verifying one of her devices.
+func TestVerificationSAS(t *testing.T) {
+	Instance().ClientTypeMatrix(t, func(t *testing.T, verifierClientType, verifieeClientType api.ClientType) {
+		if verifieeClientType.Lang == api.ClientTypeRust {
+			t.Skipf("rust cannot be a verifiee yet, see https://github.com/matrix-org/matrix-rust-sdk/issues/3595")
+		}
+		tc := Instance().CreateTestContext(t, verifierClientType)
+		verifieeUser := &cc.User{
+			CSAPI:      tc.Alice.CSAPI,
+			ClientType: verifieeClientType,
+		}
+
+		tc.WithAliceSyncing(t, func(verifier api.Client) {
+			tc.WithClientSyncing(t, &cc.ClientCreationRequest{
+				User: verifieeUser,
+			}, func(verifiee api.Client) {
+
+				verifier.RequestVerification(t, &VerificationListener{})
+			})
+		})
+	})
+}
+
+type VerificationListener struct {
+	onVerificationStateChange    func(vState api.VerificationState)
+	didAcceptVerificationRequest func()
+	didReceiveVerificationData   func(vData api.VerificationData)
+	didFail                      func()
+	didCancel                    func()
+	didFinish                    func()
+}
+
+func (v *VerificationListener) Close() {}
+func (v *VerificationListener) OnVerificationStateChange(vState api.VerificationState) {
+	if v.onVerificationStateChange != nil {
+		v.onVerificationStateChange(vState)
+	}
+}
+func (v *VerificationListener) DidAcceptVerificationRequest() {
+	if v.didAcceptVerificationRequest != nil {
+		v.didAcceptVerificationRequest()
+	}
+}
+func (v *VerificationListener) DidReceiveVerificationData(vData api.VerificationData) {
+	if v.didReceiveVerificationData != nil {
+		v.didReceiveVerificationData(vData)
+	}
+}
+func (v *VerificationListener) DidFail() {
+	if v.didFail != nil {
+		v.didFail()
+	}
+}
+func (v *VerificationListener) DidCancel() {
+	if v.didCancel != nil {
+		v.didCancel()
+	}
+}
+func (v *VerificationListener) DidFinish() {
+	if v.didFinish != nil {
+		v.didFinish()
+	}
+}

--- a/tests/verification_test.go
+++ b/tests/verification_test.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -8,6 +10,50 @@ import (
 	"github.com/matrix-org/complement-crypto/internal/cc"
 	"github.com/matrix-org/complement/ct"
 )
+
+var boolTrue = true
+
+type verificationStatus struct {
+	SenderStage   api.VerificationStageTransitioned
+	ReceiverStage api.VerificationStageTransitioned
+
+	SenderDone   bool
+	ReceiverDone bool
+
+	mu *sync.Mutex
+}
+
+// done returns true iff the sender and receiver are both done.
+func (s *verificationStatus) done(senderDone, receiverDone *bool) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if senderDone != nil {
+		s.SenderDone = *senderDone
+	}
+	if receiverDone != nil {
+		s.ReceiverDone = *receiverDone
+	}
+	return s.SenderDone && s.ReceiverDone
+}
+
+func (s *verificationStatus) attemptVerification(t *testing.T) {
+	if s.ReceiverStage == nil || s.SenderStage == nil {
+		return // we don't have emoji from both sides yet
+	}
+	senderEmoji := s.SenderStage.VerificationData().Emojis
+	receiverEmoji := s.ReceiverStage.VerificationData().Emojis
+	t.Logf("[SENDER]   %v", senderEmoji)
+	t.Logf("[RECEIVER] %v", receiverEmoji)
+	if reflect.DeepEqual(senderEmoji, receiverEmoji) {
+		t.Logf("...it's a match!")
+		s.SenderStage.Approve()
+		s.ReceiverStage.Approve()
+	} else {
+		t.Logf("...mismatch detected.")
+		s.SenderStage.Decline()
+		s.ReceiverStage.Decline()
+	}
+}
 
 // happy case test of Alice verifying one of her devices.
 func TestVerificationSAS(t *testing.T) {
@@ -28,6 +74,9 @@ func TestVerificationSAS(t *testing.T) {
 					DeviceID: "OTHER_DEVICE",
 				},
 			}, func(verifiee api.Client) {
+				status := &verificationStatus{
+					mu: &sync.Mutex{},
+				}
 				verifier.Logf(t, "Verifier(SENDER) %s %s", verifierClientType.Lang, verifier.Opts().DeviceID)
 				verifiee.Logf(t, "Verifiee(RECEIVER) %s %s", verifieeClientType.Lang, verifiee.Opts().DeviceID)
 				verifieeStage := verifiee.ListenForVerificationRequests(t)
@@ -36,7 +85,7 @@ func TestVerificationSAS(t *testing.T) {
 					select {
 					case receiverStage := <-verifieeStage:
 						switch stage := receiverStage.(type) {
-						case api.VerificationStageRequestedRequetee:
+						case api.VerificationStageRequestedReceiver:
 							t.Logf("[RECEIVER]VerificationStageRequestedRequetee: %+v", stage.Request())
 							stage.Ready()
 						case api.VerificationStageRequested:
@@ -45,34 +94,43 @@ func TestVerificationSAS(t *testing.T) {
 							t.Logf("[RECEIVER]VerificationStageReady")
 						case api.VerificationStageTransitioned:
 							t.Logf("[RECEIVER]VerificationStageTransitioned")
-							t.Logf("[RECEIVER] Emoji: %v Decimals: %v", stage.VerificationData().Emojis, stage.VerificationData().Decimals)
+							status.mu.Lock()
+							status.ReceiverStage = stage
+							status.attemptVerification(t)
+							status.mu.Unlock()
 						case api.VerificationStageStart:
 							t.Logf("[RECEIVER]VerificationStageStart")
 							stage.Transition()
 						case api.VerificationStageDone:
 							t.Logf("[RECEIVER]VerificationStageDone")
-							return
+							if status.done(nil, &boolTrue) {
+								return
+							}
 						case api.VerificationStageCancelled: // should not be cancelled
 							ct.Errorf(t, "[RECEIVER]VerificationStageCancelled")
 						}
 					case senderStage := <-verifierStage:
 						switch stage := senderStage.(type) {
-						case api.VerificationStageRequestedRequetee: // the verifier should not get a requestee state
-							ct.Errorf(t, "[SENDER]VerificationStageRequestedRequetee: %+v", stage.Request())
+						case api.VerificationStageRequestedReceiver: // the verifier should not get a requestee state
+							ct.Errorf(t, "[SENDER]VerificationStageRequestedReceiver: %+v", stage.Request())
 						case api.VerificationStageRequested:
 							t.Logf("[SENDER]VerificationStageRequested: %+v", stage.Request())
 						case api.VerificationStageReady:
-							t.Logf("[SENDER]VerificationStageReady")
 							t.Logf("[SENDER]VerificationStageReady: starting m.sas.v1")
 							stage.Start("m.sas.v1")
 						case api.VerificationStageTransitioned:
 							t.Logf("[SENDER]VerificationStageTransitioned")
-							t.Logf("[SENDER] Emoji: %v Decimals: %v", stage.VerificationData().Emojis, stage.VerificationData().Decimals)
+							status.mu.Lock()
+							status.SenderStage = stage
+							status.attemptVerification(t)
+							status.mu.Unlock()
 						case api.VerificationStageStart:
 							t.Logf("[SENDER]VerificationStageStart")
 						case api.VerificationStageDone:
 							t.Logf("[SENDER]VerificationStageDone")
-							return
+							if status.done(&boolTrue, nil) {
+								return
+							}
 						case api.VerificationStageCancelled: // should not be cancelled
 							ct.Errorf(t, "[SENDER]VerificationStageCancelled")
 						}

--- a/tests/verification_test.go
+++ b/tests/verification_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"testing"
+	"time"
 
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/cc"
@@ -22,11 +23,14 @@ func TestVerificationSAS(t *testing.T) {
 		tc.WithAliceSyncing(t, func(verifier api.Client) {
 			tc.WithClientSyncing(t, &cc.ClientCreationRequest{
 				User: verifieeUser,
+				Opts: api.ClientCreationOpts{
+					DeviceID: "OTHER_DEVICE",
+				},
 			}, func(verifiee api.Client) {
-
-				verifier.RequestVerification(t, &VerificationListener{})
+				verifier.RequestOwnUserVerification(t, &VerificationListener{})
 			})
 		})
+		time.Sleep(time.Second)
 	})
 }
 


### PR DESCRIPTION
This PR implements own user verification (cross-signing) for sender=rust, receiver=js. It forms part of https://github.com/matrix-org/complement-crypto/issues/72

This is a chunky PR, but can mercifully be thought of as 4 distinct sections:
 - The exposed complement-crypto API for key verification:
     * `internal/api/client.go`
     * `internal/api/verification.go`
 - The JS implementation of the API:
    * `internal/api/js/*`
  - The Rust implementation of the API:
    * `internal/api/rust/*`
 - The test which uses the API:
     * `tests/verification_test.go`

There are a number of TODOs here to keep the size of this smaller:
 - the RPC client impl is not implemented
 - JS clients cannot request verification yet, only rust can.

These will be fixed in another PR.

The most important bit to review is the API, as that is what test writers will interact with. This is described in more detail below:

----

- `internal/api/client.go`: this is the entry point for verification. It's a function that determines if you are the sender or receiver for the key verification process. Either way, you get back a channel of `VerificationStage`s. Using channels is nice because you can `select` over multiple channels at once, meaning the test doesn't need to have multiple goroutines (one for sender, one for receiver), the `select` effectively serialises changes. Using `select` also has the benefit that it is trivial to implement a timeout function via `case <-time.After(5 * time.Second):` - this means we will fail the test if there is no state change in 5 seconds, rather than wedging indefinitely.
- `internal/api/verification.go`: this has a lot of interfaces and enums and structs, but in essence it just defines the states that the verification state machine can be in. Every client must implement these states. By having an interface per state, it means we can guide the caller into performing valid state transitions i.e you cannot go from a cancelled state to a ready state, there physically isn't a function you can call. In contrast, the ready state has a `Cancel()` function which will transition to the cancelled state.
- `VerificationContainer`: To aid client implementations there is a `VerificationContainer` which can store all relevant verification functionality and data, and it satisfies all state interfaces. Unfortunately, Go is not expressive enough to be able to say "convert `VerificationContainer` to thing which _only_ satisfies this interface". Whilst you can trivially assign to an interface, the duck typing combined with the concrete type implementing all states means the first type assertion will _always_ match. To work around this, enums and concrete structs for each stage are added, which is what `func (c *VerificationContainer) Stage(stageEnum VerificationStageEnum) VerificationStage` does. This maps the container to a smaller struct which _only_ implements the desired interface. 