### PR TITLE
Use LTS nodejs in github workflows

### DIFF
--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -113,11 +113,11 @@ jobs:
 
         # JS SDK only steps
         # The aim is to provide the right location of the JS SDK to rebuild_js_sdk.sh
-        - name: Setup | Node.js 18.x
+        - name: Setup | Node.js LTS
           if: ${{ inputs.use_js_sdk != '' }}
           uses: actions/setup-node@v3
           with:
-            node-version: 18
+            node-version: "lts/*"
         - name: "Install JS SDK"
           if: ${{ inputs.use_js_sdk != '' }}
           shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,10 +32,10 @@ jobs:
       - uses: actions/checkout@v3 # Checkout crypto tests
 
       # Install Node, Go and Rust, along with libolm and gotestfmt
-      - name: Setup | Node.js 18.x
+      - name: Setup | Node.js LTS
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: "lts/*"
           cache: 'yarn'
           cache-dependency-path: "internal/api/js/js-sdk/yarn.lock"
       - name: Setup | Go


### PR DESCRIPTION
Currently our GH workflows all use nodejs 18, but that's not compatible with the stated support range of matrix-js-sdk, which requires the latest LTS nodejs.

Switch to LTS nodejs for the places we set up nodejs.