### PR TITLE
mitmproxy: let the callback addon modify response data

### DIFF
--- a/internal/deploy/mitm.go
+++ b/internal/deploy/mitm.go
@@ -152,7 +152,7 @@ type MITMPathConfiguration struct {
 	path        string
 	accessToken string
 	method      string
-	listener    func(cd CallbackData)
+	listener    func(cd CallbackData) *CallbackResponse
 
 	blockCount      int
 	blockStatusCode int
@@ -180,7 +180,7 @@ func (p *MITMPathConfiguration) filter() string {
 	return s.String()
 }
 
-func (p *MITMPathConfiguration) Listen(cb func(cd CallbackData)) *MITMPathConfiguration {
+func (p *MITMPathConfiguration) Listen(cb func(cd CallbackData) *CallbackResponse) *MITMPathConfiguration {
 	p.listener = cb
 	return p
 }

--- a/tests/delayed_requests_test.go
+++ b/tests/delayed_requests_test.go
@@ -39,7 +39,7 @@ func TestDelayedInviteResponse(t *testing.T) {
 
 			config := tc.Deployment.MITM().Configure(t)
 			serverHasInvite := helpers.NewWaiter()
-			config.ForPath("/sync").AccessToken(alice.CurrentAccessToken(t)).Listen(func(cd deploy.CallbackData) {
+			config.ForPath("/sync").AccessToken(alice.CurrentAccessToken(t)).Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
 				if strings.Contains(
 					strings.ReplaceAll(string(cd.ResponseBody), " ", ""),
 					`"membership":"invite"`,
@@ -50,6 +50,7 @@ func TestDelayedInviteResponse(t *testing.T) {
 					serverHasInvite.Finish()
 					time.Sleep(delayTime)
 				}
+				return nil
 			})
 			config.Execute(func() {
 				t.Logf("Alice about to /invite Bob")

--- a/tests/device_keys_test.go
+++ b/tests/device_keys_test.go
@@ -26,8 +26,9 @@ func TestFailedDeviceKeyDownloadRetries(t *testing.T) {
 
 		// Given that the first 4 attempts to download device keys will fail
 		mitmConfiguration := tc.Deployment.MITM().Configure(t)
-		mitmConfiguration.ForPath("/keys/query").Method("POST").BlockRequest(4, http.StatusGatewayTimeout).Listen(func(data deploy.CallbackData) {
+		mitmConfiguration.ForPath("/keys/query").Method("POST").BlockRequest(4, http.StatusGatewayTimeout).Listen(func(data deploy.CallbackData) *deploy.CallbackResponse {
 			queryReceived.Store(true)
+			return nil
 		})
 		mitmConfiguration.Execute(func() {
 			// And Alice and Bob are in an encrypted room together

--- a/tests/notification_test.go
+++ b/tests/notification_test.go
@@ -568,9 +568,9 @@ func TestMultiprocessDupeOTKUpload(t *testing.T) {
 	// at once. If the NSE and main apps are talking to each other, they should be using the same key ID + key.
 	// If not... well, that's a bug because then the client will forget one of these keys.
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd deploy.CallbackData) {
+	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
 		if cd.AccessToken != aliceAccessToken {
-			return // let bob upload OTKs
+			return nil // let bob upload OTKs
 		}
 		aliceUploadedNewKeys = true
 		if cd.ResponseCode != 200 {
@@ -581,6 +581,7 @@ func TestMultiprocessDupeOTKUpload(t *testing.T) {
 		// tarpit the response
 		t.Logf("tarpitting keys/upload response for 4 seconds")
 		time.Sleep(4 * time.Second)
+		return nil
 	})
 	mitmConfiguration.Execute(func() {
 		var eventID string

--- a/tests/one_time_keys_test.go
+++ b/tests/one_time_keys_test.go
@@ -205,12 +205,13 @@ func TestFailedKeysClaimRetries(t *testing.T) {
 			roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
 			// block /keys/claim and join the room, causing the Olm session to be created
 			mitmConfiguration := tc.Deployment.MITM().Configure(t)
-			mitmConfiguration.ForPath("/keys/claim").Method("POST").BlockRequest(2, http.StatusGatewayTimeout).Listen(func(cd deploy.CallbackData) {
+			mitmConfiguration.ForPath("/keys/claim").Method("POST").BlockRequest(2, http.StatusGatewayTimeout).Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
 				t.Logf("%+v", cd)
 				if cd.ResponseCode == 200 {
 					waiter.Finish()
 					stopPoking.Store(true)
 				}
+				return nil
 			})
 			mitmConfiguration.Execute(func() {
 				// join the room. This should cause an Olm session to be made but it will fail as we cannot

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -17,11 +17,12 @@ import (
 
 func sniffToDeviceEvent(t *testing.T, tc *cc.TestContext, ch chan deploy.CallbackData) *deploy.MITMConfiguration {
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/sendToDevice").Method("PUT").Listen(func(cd deploy.CallbackData) {
+	mitmConfiguration.ForPath("/sendToDevice").Method("PUT").Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
 		if strings.Contains(cd.URL, "m.room.encrypted") {
 			// we can't decrypt this, but we know that this should most likely be the m.room_key to-device event.
 			ch <- cd
 		}
+		return nil
 	})
 	return mitmConfiguration
 }


### PR DESCRIPTION
Not currently used in tests. With integreation tests.

The next step is to allow the `callback` addon to implement the last remaining feature of the `status_code` addon, which is the ability to _block requests from reaching the server_. Currently, the hook in `callback` is in the "response" flow, which means it has already reached the server. This will require some rejigging to call the callback server earlier if it has been configured that way.

Once that is done, the `status_code` addon can be removed and `callback` can be used everywhere.

Related:
 - #7 which will be easier to do when it's all Go-side code.
 - #8 which will be closed when `status_code` is removed.
 - #68 which will be much easier when there's only 1 `callback` addon involved.