### PR TITLE
Run JS SDK in separate tabs rather than browsers

### DIFF
--- a/internal/api/js/chrome/browser.go
+++ b/internal/api/js/chrome/browser.go
@@ -1,0 +1,77 @@
+package chrome
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// We only spin up a single chrome browser for all tests.
+// Each test hosts the JS SDK HTML/JS on a random high-numbered port and opens it in a new tab
+// for test isolation.
+var (
+	browserInstance   *Browser
+	browserInstanceMu = &sync.Mutex{}
+)
+
+// GlobalBrowser returns the browser singleton, making it if needed.
+func GlobalBrowser() (*Browser, error) {
+	browserInstanceMu.Lock()
+	defer browserInstanceMu.Unlock()
+	if browserInstance == nil {
+		var err error
+		browserInstance, err = NewBrowser()
+		return browserInstance, err
+	}
+	return browserInstance, nil
+}
+
+type Browser struct {
+	BaseURL         string
+	Cancel          func()
+	Ctx             context.Context // topmost chromedp context
+	ctxCancel       func()
+	execAllocCancel func()
+}
+
+// Create and run a new Chrome browser.
+func NewBrowser() (*Browser, error) {
+	ansiRedForeground := "\x1b[31m"
+	ansiResetForeground := "\x1b[39m"
+
+	colorifyError := func(format string, args ...any) {
+		format = ansiRedForeground + time.Now().Format(time.RFC3339) + " " + format + ansiResetForeground
+		fmt.Printf(format, args...)
+	}
+	opts := chromedp.DefaultExecAllocatorOptions[:]
+	os.Mkdir("chromedp", os.ModePerm) // ignore errors to allow repeated runs
+	wd, _ := os.Getwd()
+	userDir := filepath.Join(wd, "chromedp")
+	opts = append(opts,
+		chromedp.UserDataDir(userDir),
+	)
+	// increase the WS timeout from 20s (default) to 30s as we see timeouts with 20s in CI
+	opts = append(opts, chromedp.WSURLReadTimeout(30*time.Second))
+
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	ctx, cancel := chromedp.NewContext(allocCtx, chromedp.WithBrowserOption(
+		chromedp.WithBrowserLogf(colorifyError), chromedp.WithBrowserErrorf(colorifyError), //chromedp.WithBrowserDebugf(log.Printf),
+	))
+
+	browser := &Browser{
+		Ctx:             ctx,
+		ctxCancel:       cancel,
+		execAllocCancel: allocCancel,
+	}
+	return browser, chromedp.Run(ctx)
+}
+
+func (b *Browser) Close() {
+	b.ctxCancel()
+	b.execAllocCancel()
+}

--- a/internal/api/js/chrome/browser.go
+++ b/internal/api/js/chrome/browser.go
@@ -87,7 +87,7 @@ func (b *Browser) NewTab(baseJSURL string, onConsoleLog func(s string)) (*Tab, e
 		return nil, fmt.Errorf("NewTab: failed to navigate to %s: %s", baseJSURL, err)
 	}
 
-	// Listen for console logs for debugging AND to communicate live updates
+	// Listen for console logs for debugging, and to communicate live updates
 	chromedp.ListenTarget(tabCtx, func(ev interface{}) {
 		switch ev := ev.(type) {
 		case *runtime.EventConsoleAPICalled:

--- a/internal/api/js/chrome/browser.go
+++ b/internal/api/js/chrome/browser.go
@@ -77,6 +77,19 @@ func (b *Browser) Close() {
 	b.ctxCancel()
 	b.execAllocCancel()
 }
+func (b *Browser) Info() {
+	targets, err := chromedp.Targets(b.Ctx)
+	if err != nil {
+		fmt.Println("DEBUG: failed to get targets: ", err)
+		return
+	}
+	fmt.Printf("DEBUG: got %d targets\n", len(targets))
+	var urls []string
+	for _, t := range targets {
+		urls = append(urls, t.URL)
+	}
+	fmt.Println(urls)
+}
 
 func (b *Browser) NewTab(baseJSURL string, onConsoleLog func(s string)) (*Tab, error) {
 	tabCtx, closeTab := chromedp.NewContext(b.Ctx)
@@ -104,7 +117,7 @@ func (b *Browser) NewTab(baseJSURL string, onConsoleLog func(s string)) (*Tab, e
 	return &Tab{
 		BaseURL: baseJSURL,
 		Ctx:     tabCtx,
-		browser: b,
+		Browser: b,
 		cancel:  closeTab,
 	}, nil
 }

--- a/internal/api/js/chrome/chrome.go
+++ b/internal/api/js/chrome/chrome.go
@@ -54,7 +54,7 @@ func MustRunAsyncFn[T any](t ct.TestLike, ctx context.Context, js string) *T {
 
 // Run a headless JS SDK instance for the given user/device ID.
 func RunHeadless(userID, deviceID string, onConsoleLog func(s string)) (*Tab, error) {
-	// make a Chrome browser
+	// Make, or acquire, a Chrome browser
 	browser, err := GlobalBrowser()
 	if err != nil {
 		return nil, fmt.Errorf("GlobalBrowser: %s", err)

--- a/internal/api/js/chrome/tab.go
+++ b/internal/api/js/chrome/tab.go
@@ -7,22 +7,60 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 )
 
 //go:embed dist
 var jsSDKDistDirectory embed.FS
 
+var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
 type JSSDKInstanceOpts struct {
-	// The specific port this instance should be hosted on.
+	// Required. The prefix to use when constructing base URLs.
+	// This is used to namespace storage between tests by prefixing the URL e.g
+	// 'foo.localhost:12345' vs 'bar.localhost:12345'. We cannot simply use the
+	// port number alone because it is randomly allocated, which means the port
+	// number can be reused. If this happens, the 2nd+ test with the same port
+	// number will fail with:
+	//   'Error: the account in the store doesn't match the account in the constructor'
+	// By prefixing, we ensure we are treated as a different origin whilst keeping
+	// routing the same.
+	HostPrefix string
+	// Optional. The specific port this instance should be hosted on.
+	// If 0, uses a random high numbered port.
 	// This is crucial for persistent storage which relies on a stable port number
 	// across restarts.
 	Port int
 }
 
+// NewJSSDKInstanceOptsFromURL returns SDK options based on a pre-existing base URL. If the
+// base URL doesn't exist yet, create the information from the provided user/device ID.
+func NewJSSDKInstanceOptsFromURL(baseURL, userID, deviceID string) (*JSSDKInstanceOpts, error) {
+	if baseURL == "" {
+		return &JSSDKInstanceOpts{
+			HostPrefix: nonAlphanumericRegex.ReplaceAllString(userID+deviceID, ""),
+		}, nil
+	}
+	u, _ := url.Parse(baseURL)
+	portStr := u.Port()
+	port, err := strconv.Atoi(portStr)
+	if portStr == "" || err != nil {
+		return nil, fmt.Errorf("failed to extract port from base url %s", baseURL)
+	}
+
+	return &JSSDKInstanceOpts{
+		HostPrefix: strings.Split(u.Hostname(), ".")[0],
+		Port:       port,
+	}, nil
+}
+
 // NewJSSDKWebsite hosts the JS SDK HTML/JS on a random high-numbered port
 // and runs a Go web server to serve those files.
-func NewJSSDKWebsite(opts JSSDKInstanceOpts) (baseURL string, close func(), err error) {
+func NewJSSDKWebsite(opts *JSSDKInstanceOpts) (baseURL string, close func(), err error) {
 	// strip /dist so /index.html loads correctly as does /assets/xxx.js
 	c, err := fs.Sub(jsSDKDistDirectory, "dist")
 	if err != nil {
@@ -42,7 +80,9 @@ func NewJSSDKWebsite(opts JSSDKInstanceOpts) (baseURL string, close func(), err 
 		if err != nil {
 			panic(err)
 		}
-		baseURL = "http://" + ln.Addr().String()
+		baseURL = fmt.Sprintf(
+			"http://%s.localhost:%v", opts.HostPrefix, ln.Addr().(*net.TCPAddr).Port,
+		)
 		fmt.Println("JS SDK listening on", baseURL)
 		wg.Done()
 		srv.Serve(ln)

--- a/internal/api/js/chrome/tab.go
+++ b/internal/api/js/chrome/tab.go
@@ -1,0 +1,76 @@
+package chrome
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"sync"
+)
+
+//go:embed dist
+var jsSDKDistDirectory embed.FS
+
+type JSSDKInstanceOpts struct {
+	// The specific port this instance should be hosted on.
+	// This is crucial for persistent storage which relies on a stable port number
+	// across restarts.
+	Port int
+}
+
+// NewJSSDKWebsite hosts the JS SDK HTML/JS on a random high-numbered port
+// and runs a Go web server to serve those files.
+func NewJSSDKWebsite(opts JSSDKInstanceOpts) (baseURL string, close func(), err error) {
+	// strip /dist so /index.html loads correctly as does /assets/xxx.js
+	c, err := fs.Sub(jsSDKDistDirectory, "dist")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to strip /dist off JS SDK files: %s", err)
+	}
+	// run js-sdk (need to run this as a web server to avoid CORS errors you'd otherwise get with file: URLs)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	mux := &http.ServeMux{}
+	mux.Handle("/", http.FileServer(http.FS(c)))
+	srv := &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", opts.Port),
+		Handler: mux,
+	}
+	startServer := func() {
+		ln, err := net.Listen("tcp", srv.Addr)
+		if err != nil {
+			panic(err)
+		}
+		baseURL = "http://" + ln.Addr().String()
+		fmt.Println("JS SDK listening on", baseURL)
+		wg.Done()
+		srv.Serve(ln)
+		fmt.Println("JS SDK closing webserver")
+	}
+	go startServer()
+	wg.Wait()
+	return baseURL, func() {
+		srv.Close()
+	}, nil
+}
+
+// Tab represents an open JS SDK instance tab
+type Tab struct {
+	BaseURL     string
+	Ctx         context.Context // tab context
+	browser     *Browser        // a ref to the browser which made this tab
+	closeServer func()
+	cancel      func() // closes the tab
+}
+
+func (t *Tab) Close() {
+	t.cancel()
+	if t.closeServer != nil {
+		t.closeServer()
+	}
+}
+
+func (t *Tab) SetCloseServer(close func()) {
+	t.closeServer = close
+}

--- a/internal/api/js/chrome/tab.go
+++ b/internal/api/js/chrome/tab.go
@@ -99,7 +99,7 @@ func NewJSSDKWebsite(opts *JSSDKInstanceOpts) (baseURL string, close func(), err
 type Tab struct {
 	BaseURL     string
 	Ctx         context.Context // tab context
-	browser     *Browser        // a ref to the browser which made this tab
+	Browser     *Browser        // a ref to the browser which made this tab
 	closeServer func()
 	cancel      func() // closes the tab
 }

--- a/internal/api/js/js.go
+++ b/internal/api/js/js.go
@@ -715,6 +715,7 @@ func (w *jsTimelineWaiter) Waitf(t ct.TestLike, s time.Duration, format string, 
 
 func (w *jsTimelineWaiter) TryWaitf(t ct.TestLike, s time.Duration, format string, args ...any) error {
 	t.Helper()
+	w.client.tab.Browser.Info()
 	updates := make(chan bool, 3)
 	cancel := w.client.listenForUpdates(func(ctrlMsg *ControlMessage) {
 		msg := ctrlMsg.AsControlMessageEvent()


### PR DESCRIPTION
Fixes #107 and should be faster to run. The main benefit here is that we aren't relying so much on extracting the WS URL as this happens on browser startup, which has proven to be flakey.

JS only runs:
Before: ~6m10s to run.
After: ~5m50s.

Full JS/Rust combo tests:
Before: ~10m45s to run.
After: ~10m30s to run.