### PR TITLE
Revert changes to Cargo files when rebuilding rust SDK

### DIFF
--- a/rebuild_rust_sdk.sh
+++ b/rebuild_rust_sdk.sh
@@ -42,6 +42,9 @@ fi
 # replace uniffi version to one that works with uniffi-bindgen-go
 echo 'building matrix-sdk-ffi...';
 cd $RUST_SDK_DIR;
+cp Cargo.toml Cargo.toml.backup
+cp Cargo.lock Cargo.lock.backup
+trap "mv $RUST_SDK_DIR/Cargo.toml.backup $RUST_SDK_DIR/Cargo.toml; mv $RUST_SDK_DIR/Cargo.lock.backup $RUST_SDK_DIR/Cargo.lock" EXIT INT TERM
 sed -i.bak 's/uniffi =.*/uniffi = "0\.25\.3"/' Cargo.toml
 sed -i.bak 's^uniffi_bindgen =.*^uniffi_bindgen = { git = "https:\/\/github.com\/mozilla\/uniffi-rs", rev = "0a03b713306d6ce3de033157fc2ce92a238c2e24" }^' Cargo.toml
 sed -i.bak 's#matrix-sdk-crypto = {#matrix-sdk-crypto = {features = ["_disable-minimum-rotation-period-ms"],#' Cargo.toml


### PR DESCRIPTION
As complement-crypto needs an earlier version of uniffi, it needs to tweak the deps at build time. Revert them afterwards.