### PR TITLE
rust: always use persistence in clients

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -226,12 +226,14 @@ type ClientCreationOpts struct {
 	// Required. The password for this account.
 	Password string
 
-	// Optional. If true, persistent storage will be used for the same user|device ID.
-	PersistentStorage bool
 	// Required for rust clients. The URL of the sliding sync proxy.
 	SlidingSyncURL string
 	// Optional. Set this to login with this device ID.
 	DeviceID string
+
+	// A hint to the client implementation that persistent storage is required. Clients may ignore
+	// this flag and always use persistence.
+	PersistentStorage bool
 
 	// Rust only. If set, enables the cross process refresh lock on the FFI client with the process name provided.
 	EnableCrossProcessRefreshLockProcessName string

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -71,26 +71,21 @@ func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, erro
 		clientSessionDelegate = NewMemoryClientSessionDelegate()
 		ab = ab.EnableCrossProcessRefreshLock(opts.EnableCrossProcessRefreshLockProcessName, clientSessionDelegate)
 	}
-	var username string
-	if opts.PersistentStorage {
-		// @alice:hs1, FOOBAR => alice_hs1_FOOBAR
-		username = strings.Replace(opts.UserID[1:], ":", "_", -1) + "_" + opts.DeviceID
-		ab = ab.SessionPath("rust_storage/" + username).Username(username)
-	}
+	// @alice:hs1, FOOBAR => alice_hs1_FOOBAR
+	username := strings.Replace(opts.UserID[1:], ":", "_", -1) + "_" + opts.DeviceID
+	ab = ab.SessionPath("rust_storage/" + username).Username(username)
 	client, err := ab.Build()
 	if err != nil {
 		return nil, fmt.Errorf("ClientBuilder.Build failed: %s", err)
 	}
 	c := &RustClient{
-		userID:        opts.UserID,
-		FFIClient:     client,
-		roomsListener: NewRoomsListener(),
-		rooms:         make(map[string]*RustRoomInfo),
-		roomsMu:       &sync.RWMutex{},
-		opts:          opts,
-	}
-	if opts.PersistentStorage {
-		c.persistentStoragePath = "./rust_storage/" + username
+		userID:                opts.UserID,
+		FFIClient:             client,
+		roomsListener:         NewRoomsListener(),
+		rooms:                 make(map[string]*RustRoomInfo),
+		roomsMu:               &sync.RWMutex{},
+		opts:                  opts,
+		persistentStoragePath: "./rust_storage/" + username,
 	}
 	if opts.AccessToken != "" { // restore the session
 		session := matrix_sdk_ffi.Session{


### PR DESCRIPTION
Previously we would only use persistence when the test strictly needed it e.g to test what happens between restarts. It's preferable to always run with persistence because:
 - it more accurately models real Element X clients e.g performance characteristics, runtime code.
 - any bugs in the DB layer are then also bugs in the client. Using the memory store has proven [error prone](https://github.com/matrix-org/matrix-rust-sdk/pull/3668) and fixing these bugs don't improve the stability of EX at all.

`ClientCreationOpts` will still have the `Persistence` flag though, as it remains useful to know when a test _needs_ persistence vs when it does not. In the future, we may clean up locally stored files during test runtime, and this flag would allow us to know whether it is safe to delete the files or not.