### PR TITLE
Basic reshuffling of callback/mitm code

### DIFF
--- a/internal/deploy/callback/callback_addon.go
+++ b/internal/deploy/callback/callback_addon.go
@@ -1,4 +1,4 @@
-package deploy
+package callback
 
 import (
 	"encoding/base64"

--- a/internal/deploy/callback_addon_test.go
+++ b/internal/deploy/callback_addon_test.go
@@ -295,11 +295,11 @@ func TestCallbackAddon(t *testing.T) {
 			}
 
 			mitmClient := deployment.MITM()
-			lockID := mitmClient.lockOptions(t, map[string]any{
+			lockID := mitmClient.LockOptions(t, map[string]any{
 				"callback": callbackOpts,
 			})
 			tc.inner(t, checker)
-			mitmClient.unlockOptions(t, lockID)
+			mitmClient.UnlockOptions(t, lockID)
 		})
 	}
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -34,7 +34,7 @@ const mitmDumpFilePathOnContainer = "/tmp/mitm.dump"
 type SlidingSyncDeployment struct {
 	complement.Deployment
 	extraContainers      map[string]testcontainers.Container
-	mitmClient           *mitm.MITMClient
+	mitmClient           *mitm.Client
 	ControllerURL        string
 	dnsToReverseProxyURL map[string]string
 	mu                   sync.RWMutex
@@ -43,7 +43,7 @@ type SlidingSyncDeployment struct {
 
 // MITM returns a client capable of configuring man-in-the-middle operations such as
 // snooping on CSAPI traffic and modifying responses.
-func (d *SlidingSyncDeployment) MITM() *mitm.MITMClient {
+func (d *SlidingSyncDeployment) MITM() *mitm.Client {
 	return d.mitmClient
 }
 
@@ -327,7 +327,7 @@ func RunNewDeployment(t *testing.T, mitmProxyAddonsDir string, mitmDumpFile stri
 			"mitmproxy": mitmproxyContainer,
 		},
 		ControllerURL: controllerURL,
-		mitmClient:    mitm.NewMITMClient(proxyURL, deployment.GetConfig().HostnameRunningComplement),
+		mitmClient:    mitm.NewClient(proxyURL, deployment.GetConfig().HostnameRunningComplement),
 		dnsToReverseProxyURL: map[string]string{
 			"hs1":      rpHS1URL,
 			"hs2":      rpHS2URL,

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/matrix-org/complement"
 	"github.com/matrix-org/complement-crypto/internal/api"
+	"github.com/matrix-org/complement-crypto/internal/deploy/mitm"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/helpers"
@@ -33,7 +34,7 @@ const mitmDumpFilePathOnContainer = "/tmp/mitm.dump"
 type SlidingSyncDeployment struct {
 	complement.Deployment
 	extraContainers      map[string]testcontainers.Container
-	mitmClient           *MITMClient
+	mitmClient           *mitm.MITMClient
 	ControllerURL        string
 	dnsToReverseProxyURL map[string]string
 	mu                   sync.RWMutex
@@ -42,7 +43,7 @@ type SlidingSyncDeployment struct {
 
 // MITM returns a client capable of configuring man-in-the-middle operations such as
 // snooping on CSAPI traffic and modifying responses.
-func (d *SlidingSyncDeployment) MITM() *MITMClient {
+func (d *SlidingSyncDeployment) MITM() *mitm.MITMClient {
 	return d.mitmClient
 }
 
@@ -326,7 +327,7 @@ func RunNewDeployment(t *testing.T, mitmProxyAddonsDir string, mitmDumpFile stri
 			"mitmproxy": mitmproxyContainer,
 		},
 		ControllerURL: controllerURL,
-		mitmClient:    NewMITMClient(proxyURL, deployment.GetConfig().HostnameRunningComplement),
+		mitmClient:    mitm.NewMITMClient(proxyURL, deployment.GetConfig().HostnameRunningComplement),
 		dnsToReverseProxyURL: map[string]string{
 			"hs1":      rpHS1URL,
 			"hs2":      rpHS2URL,

--- a/internal/deploy/mitm/client.go
+++ b/internal/deploy/mitm/client.go
@@ -21,13 +21,13 @@ var (
 	boolFalse = false
 )
 
-type MITMClient struct {
+type Client struct {
 	client                    *http.Client
 	hostnameRunningComplement string
 }
 
-func NewMITMClient(proxyURL *url.URL, hostnameRunningComplement string) *MITMClient {
-	return &MITMClient{
+func NewClient(proxyURL *url.URL, hostnameRunningComplement string) *Client {
+	return &Client{
 		hostnameRunningComplement: hostnameRunningComplement,
 		client: &http.Client{
 			Timeout: 5 * time.Second,
@@ -38,8 +38,8 @@ func NewMITMClient(proxyURL *url.URL, hostnameRunningComplement string) *MITMCli
 	}
 }
 
-func (m *MITMClient) Configure(t *testing.T) *MITMConfiguration {
-	return &MITMConfiguration{
+func (m *Client) Configure(t *testing.T) *Configuration {
+	return &Configuration{
 		t:        t,
 		pathCfgs: make(map[string]*MITMPathConfiguration),
 		mu:       &sync.Mutex{},
@@ -47,7 +47,7 @@ func (m *MITMClient) Configure(t *testing.T) *MITMConfiguration {
 	}
 }
 
-func (m *MITMClient) lockOptions(t *testing.T, options map[string]any) (lockID []byte) {
+func (m *Client) lockOptions(t *testing.T, options map[string]any) (lockID []byte) {
 	jsonBody, err := json.Marshal(map[string]interface{}{
 		"options": options,
 	})
@@ -65,7 +65,7 @@ func (m *MITMClient) lockOptions(t *testing.T, options map[string]any) (lockID [
 	return lockID
 }
 
-func (m *MITMClient) unlockOptions(t *testing.T, lockID []byte) {
+func (m *Client) unlockOptions(t *testing.T, lockID []byte) {
 	t.Logf("unlockOptions")
 	req, err := http.NewRequest("POST", magicMITMURL+"/options/unlock", bytes.NewBuffer(lockID))
 	must.NotError(t, "failed to prepare request", err)

--- a/internal/deploy/mitm/client.go
+++ b/internal/deploy/mitm/client.go
@@ -1,0 +1,76 @@
+package mitm
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matrix-org/complement/must"
+)
+
+// must match the value in tests/addons/__init__.py
+const magicMITMURL = "http://mitm.code"
+
+var (
+	boolTrue  = true
+	boolFalse = false
+)
+
+type MITMClient struct {
+	client                    *http.Client
+	hostnameRunningComplement string
+}
+
+func NewMITMClient(proxyURL *url.URL, hostnameRunningComplement string) *MITMClient {
+	return &MITMClient{
+		hostnameRunningComplement: hostnameRunningComplement,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				Proxy: http.ProxyURL(proxyURL),
+			},
+		},
+	}
+}
+
+func (m *MITMClient) Configure(t *testing.T) *MITMConfiguration {
+	return &MITMConfiguration{
+		t:        t,
+		pathCfgs: make(map[string]*MITMPathConfiguration),
+		mu:       &sync.Mutex{},
+		client:   m,
+	}
+}
+
+func (m *MITMClient) lockOptions(t *testing.T, options map[string]any) (lockID []byte) {
+	jsonBody, err := json.Marshal(map[string]interface{}{
+		"options": options,
+	})
+	t.Logf("lockOptions: %v", string(jsonBody))
+	must.NotError(t, "failed to marshal options", err)
+	u := magicMITMURL + "/options/lock"
+	req, err := http.NewRequest("POST", u, bytes.NewBuffer(jsonBody))
+	must.NotError(t, "failed to prepare request", err)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := m.client.Do(req)
+	must.NotError(t, "failed to POST "+u, err)
+	must.Equal(t, res.StatusCode, 200, "controller returned wrong HTTP status")
+	lockID, err = io.ReadAll(res.Body)
+	must.NotError(t, "failed to read response", err)
+	return lockID
+}
+
+func (m *MITMClient) unlockOptions(t *testing.T, lockID []byte) {
+	t.Logf("unlockOptions")
+	req, err := http.NewRequest("POST", magicMITMURL+"/options/unlock", bytes.NewBuffer(lockID))
+	must.NotError(t, "failed to prepare request", err)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := m.client.Do(req)
+	must.NotError(t, "failed to do request", err)
+	must.Equal(t, res.StatusCode, 200, "controller returned wrong HTTP status")
+}

--- a/internal/deploy/mitm/client.go
+++ b/internal/deploy/mitm/client.go
@@ -47,7 +47,16 @@ func (m *Client) Configure(t *testing.T) *Configuration {
 	}
 }
 
-func (m *Client) lockOptions(t *testing.T, options map[string]any) (lockID []byte) {
+// Lock mitmproxy with the given set of options.
+//
+// If mitmproxy is already locked, this will fail the test. This is a low-level
+// function which provides an escape hatch if the test needs special mitmproxy
+// options. See https://docs.mitmproxy.org/stable/concepts-options/ for more
+// information about options.
+//
+// In general, tests should not call this function, preferring to use .Configure
+// which has a friendlier API shape.
+func (m *Client) LockOptions(t *testing.T, options map[string]any) (lockID []byte) {
 	jsonBody, err := json.Marshal(map[string]interface{}{
 		"options": options,
 	})
@@ -65,7 +74,17 @@ func (m *Client) lockOptions(t *testing.T, options map[string]any) (lockID []byt
 	return lockID
 }
 
-func (m *Client) unlockOptions(t *testing.T, lockID []byte) {
+// Unlock mitmproxy using the lock ID provided.
+//
+// If mitmproxy is already unlocked, this will fail the test. If the lock ID
+// does not match the ID of the existing lock, this will fail the test.
+// This is a low-level function which provides an escape hatch if the test
+// needs special mitmproxy options. See https://docs.mitmproxy.org/stable/concepts-options/
+// for more information about options.
+//
+// In general, tests should not call this function, preferring to use .Configure
+// which has a friendlier API shape.
+func (m *Client) UnlockOptions(t *testing.T, lockID []byte) {
 	t.Logf("unlockOptions")
 	req, err := http.NewRequest("POST", magicMITMURL+"/options/unlock", bytes.NewBuffer(lockID))
 	must.NotError(t, "failed to prepare request", err)

--- a/internal/deploy/mitm/configuration.go
+++ b/internal/deploy/mitm/configuration.go
@@ -85,10 +85,10 @@ func (c *Configuration) Execute(inner func()) {
 	}
 	c.mu.Unlock()
 
-	lockID := c.client.lockOptions(c.t, map[string]any{
+	lockID := c.client.LockOptions(c.t, map[string]any{
 		"callback": callbackAddon,
 	})
-	defer c.client.unlockOptions(c.t, lockID)
+	defer c.client.UnlockOptions(c.t, lockID)
 	inner()
 
 }

--- a/internal/deploy/mitm/configuration.go
+++ b/internal/deploy/mitm/configuration.go
@@ -1,83 +1,16 @@
-package deploy
+package mitm
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
-	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/matrix-org/complement-crypto/internal/deploy/callback"
 	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/must"
 )
-
-// must match the value in tests/addons/__init__.py
-const magicMITMURL = "http://mitm.code"
-
-var (
-	boolTrue  = true
-	boolFalse = false
-)
-
-type MITMClient struct {
-	client                    *http.Client
-	hostnameRunningComplement string
-}
-
-func NewMITMClient(proxyURL *url.URL, hostnameRunningComplement string) *MITMClient {
-	return &MITMClient{
-		hostnameRunningComplement: hostnameRunningComplement,
-		client: &http.Client{
-			Timeout: 5 * time.Second,
-			Transport: &http.Transport{
-				Proxy: http.ProxyURL(proxyURL),
-			},
-		},
-	}
-}
-
-func (m *MITMClient) Configure(t *testing.T) *MITMConfiguration {
-	return &MITMConfiguration{
-		t:        t,
-		pathCfgs: make(map[string]*MITMPathConfiguration),
-		mu:       &sync.Mutex{},
-		client:   m,
-	}
-}
-
-func (m *MITMClient) lockOptions(t *testing.T, options map[string]any) (lockID []byte) {
-	jsonBody, err := json.Marshal(map[string]interface{}{
-		"options": options,
-	})
-	t.Logf("lockOptions: %v", string(jsonBody))
-	must.NotError(t, "failed to marshal options", err)
-	u := magicMITMURL + "/options/lock"
-	req, err := http.NewRequest("POST", u, bytes.NewBuffer(jsonBody))
-	must.NotError(t, "failed to prepare request", err)
-	req.Header.Set("Content-Type", "application/json")
-	res, err := m.client.Do(req)
-	must.NotError(t, "failed to POST "+u, err)
-	must.Equal(t, res.StatusCode, 200, "controller returned wrong HTTP status")
-	lockID, err = io.ReadAll(res.Body)
-	must.NotError(t, "failed to read response", err)
-	return lockID
-}
-
-func (m *MITMClient) unlockOptions(t *testing.T, lockID []byte) {
-	t.Logf("unlockOptions")
-	req, err := http.NewRequest("POST", magicMITMURL+"/options/unlock", bytes.NewBuffer(lockID))
-	must.NotError(t, "failed to prepare request", err)
-	req.Header.Set("Content-Type", "application/json")
-	res, err := m.client.Do(req)
-	must.NotError(t, "failed to do request", err)
-	must.Equal(t, res.StatusCode, 200, "controller returned wrong HTTP status")
-}
 
 // MITMConfiguration represent a single mitmproxy configuration, with all options specified.
 //

--- a/tests/delayed_requests_test.go
+++ b/tests/delayed_requests_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/complement-crypto/internal/api"
-	"github.com/matrix-org/complement-crypto/internal/deploy"
+	"github.com/matrix-org/complement-crypto/internal/deploy/callback"
 	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/must"
@@ -39,7 +39,7 @@ func TestDelayedInviteResponse(t *testing.T) {
 
 			config := tc.Deployment.MITM().Configure(t)
 			serverHasInvite := helpers.NewWaiter()
-			config.ForPath("/sync").AccessToken(alice.CurrentAccessToken(t)).Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+			config.ForPath("/sync").AccessToken(alice.CurrentAccessToken(t)).Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 				if strings.Contains(
 					strings.ReplaceAll(string(cd.ResponseBody), " ", ""),
 					`"membership":"invite"`,

--- a/tests/delayed_requests_test.go
+++ b/tests/delayed_requests_test.go
@@ -39,7 +39,7 @@ func TestDelayedInviteResponse(t *testing.T) {
 
 			config := tc.Deployment.MITM().Configure(t)
 			serverHasInvite := helpers.NewWaiter()
-			config.ForPath("/sync").AccessToken(alice.CurrentAccessToken(t)).Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+			config.ForPath("/sync").AccessToken(alice.CurrentAccessToken(t)).Listen(func(cd callback.Data) *callback.Response {
 				if strings.Contains(
 					strings.ReplaceAll(string(cd.ResponseBody), " ", ""),
 					`"membership":"invite"`,

--- a/tests/device_keys_test.go
+++ b/tests/device_keys_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/cc"
-	"github.com/matrix-org/complement-crypto/internal/deploy"
+	"github.com/matrix-org/complement-crypto/internal/deploy/callback"
 	"github.com/matrix-org/complement/must"
 )
 
@@ -26,7 +26,7 @@ func TestFailedDeviceKeyDownloadRetries(t *testing.T) {
 
 		// Given that the first 4 attempts to download device keys will fail
 		mitmConfiguration := tc.Deployment.MITM().Configure(t)
-		mitmConfiguration.ForPath("/keys/query").Method("POST").BlockRequest(4, http.StatusGatewayTimeout).Listen(func(data deploy.CallbackData) *deploy.CallbackResponse {
+		mitmConfiguration.ForPath("/keys/query").Method("POST").BlockRequest(4, http.StatusGatewayTimeout).Listen(func(data callback.CallbackData) *callback.CallbackResponse {
 			queryReceived.Store(true)
 			return nil
 		})

--- a/tests/device_keys_test.go
+++ b/tests/device_keys_test.go
@@ -26,7 +26,7 @@ func TestFailedDeviceKeyDownloadRetries(t *testing.T) {
 
 		// Given that the first 4 attempts to download device keys will fail
 		mitmConfiguration := tc.Deployment.MITM().Configure(t)
-		mitmConfiguration.ForPath("/keys/query").Method("POST").BlockRequest(4, http.StatusGatewayTimeout).Listen(func(data callback.CallbackData) *callback.CallbackResponse {
+		mitmConfiguration.ForPath("/keys/query").Method("POST").BlockRequest(4, http.StatusGatewayTimeout).Listen(func(data callback.Data) *callback.Response {
 			queryReceived.Store(true)
 			return nil
 		})

--- a/tests/notification_test.go
+++ b/tests/notification_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/cc"
-	"github.com/matrix-org/complement-crypto/internal/deploy"
+	"github.com/matrix-org/complement-crypto/internal/deploy/callback"
 	"github.com/matrix-org/complement/must"
 )
 
@@ -568,7 +568,7 @@ func TestMultiprocessDupeOTKUpload(t *testing.T) {
 	// at once. If the NSE and main apps are talking to each other, they should be using the same key ID + key.
 	// If not... well, that's a bug because then the client will forget one of these keys.
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 		if cd.AccessToken != aliceAccessToken {
 			return nil // let bob upload OTKs
 		}

--- a/tests/notification_test.go
+++ b/tests/notification_test.go
@@ -568,7 +568,7 @@ func TestMultiprocessDupeOTKUpload(t *testing.T) {
 	// at once. If the NSE and main apps are talking to each other, they should be using the same key ID + key.
 	// If not... well, that's a bug because then the client will forget one of these keys.
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.Data) *callback.Response {
 		if cd.AccessToken != aliceAccessToken {
 			return nil // let bob upload OTKs
 		}

--- a/tests/one_time_keys_test.go
+++ b/tests/one_time_keys_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/cc"
-	"github.com/matrix-org/complement-crypto/internal/deploy"
+	"github.com/matrix-org/complement-crypto/internal/deploy/callback"
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/ct"
@@ -205,7 +205,7 @@ func TestFailedKeysClaimRetries(t *testing.T) {
 			roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
 			// block /keys/claim and join the room, causing the Olm session to be created
 			mitmConfiguration := tc.Deployment.MITM().Configure(t)
-			mitmConfiguration.ForPath("/keys/claim").Method("POST").BlockRequest(2, http.StatusGatewayTimeout).Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+			mitmConfiguration.ForPath("/keys/claim").Method("POST").BlockRequest(2, http.StatusGatewayTimeout).Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 				t.Logf("%+v", cd)
 				if cd.ResponseCode == 200 {
 					waiter.Finish()

--- a/tests/one_time_keys_test.go
+++ b/tests/one_time_keys_test.go
@@ -205,7 +205,7 @@ func TestFailedKeysClaimRetries(t *testing.T) {
 			roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
 			// block /keys/claim and join the room, causing the Olm session to be created
 			mitmConfiguration := tc.Deployment.MITM().Configure(t)
-			mitmConfiguration.ForPath("/keys/claim").Method("POST").BlockRequest(2, http.StatusGatewayTimeout).Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+			mitmConfiguration.ForPath("/keys/claim").Method("POST").BlockRequest(2, http.StatusGatewayTimeout).Listen(func(cd callback.Data) *callback.Response {
 				t.Logf("%+v", cd)
 				if cd.ResponseCode == 200 {
 					waiter.Finish()

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/matrix-org/complement/must"
 )
 
-func sniffToDeviceEvent(t *testing.T, tc *cc.TestContext, ch chan callback.CallbackData) *mitm.MITMConfiguration {
+func sniffToDeviceEvent(t *testing.T, tc *cc.TestContext, ch chan callback.Data) *mitm.Configuration {
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/sendToDevice").Method("PUT").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+	mitmConfiguration.ForPath("/sendToDevice").Method("PUT").Listen(func(cd callback.Data) *callback.Response {
 		if strings.Contains(cd.URL, "m.room.encrypted") {
 			// we can't decrypt this, but we know that this should most likely be the m.room_key to-device event.
 			ch <- cd
@@ -60,7 +60,7 @@ func TestRoomKeyIsCycledOnDeviceLogout(t *testing.T) {
 			waiter2.Waitf(t, 5*time.Second, "alice2 did not see alice's message")
 
 			// we're going to sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.CallbackData, 10)
+			ch := make(chan callback.Data, 10)
 			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
 
 			alice2StopSyncing()
@@ -127,7 +127,7 @@ func TestRoomKeyIsCycledAfterEnoughMessages(t *testing.T) {
 			}
 
 			// Sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.CallbackData, 10)
+			ch := make(chan callback.Data, 10)
 			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
 			mitmConfiguration.Execute(func() {
 				// When we send two messages (one to hit the threshold and one to pass it)
@@ -207,7 +207,7 @@ func TestRoomKeyIsCycledAfterEnoughTime(t *testing.T) {
 			waiter.Waitf(t, 5*time.Second, "Did not see 'before we start' event in the room")
 
 			// Sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.CallbackData, 10)
+			ch := make(chan callback.Data, 10)
 			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
 			mitmConfiguration.Execute(func() {
 				// Send a message to ensure the room is working, and any timer is set up
@@ -262,7 +262,7 @@ func TestRoomKeyIsCycledOnMemberLeaving(t *testing.T) {
 			waiter2.Waitf(t, 5*time.Second, "charlie did not see alice's message")
 
 			// we're going to sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.CallbackData, 10)
+			ch := make(chan callback.Data, 10)
 			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
 
 			// we don't know when the new room key will be sent, it could be sent as soon as the device list update
@@ -314,7 +314,7 @@ func TestRoomKeyIsNotCycled(t *testing.T) {
 			waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
 
 			// we're going to sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.CallbackData, 10)
+			ch := make(chan callback.Data, 10)
 			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
 
 			t.Run("on display name change", func(t *testing.T) {
@@ -463,7 +463,7 @@ func testRoomKeyIsNotCycledOnClientRestartRust(t *testing.T, clientType api.Clie
 		// Now recreate the same client and make sure we don't send new room keys.
 
 		// we're going to sniff calls to /sendToDevice to ensure we do NOT see a new room key being sent.
-		ch := make(chan callback.CallbackData, 10)
+		ch := make(chan callback.Data, 10)
 		mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
 		mitmConfiguration.Execute(func() {
 			// login as alice
@@ -526,7 +526,7 @@ func testRoomKeyIsNotCycledOnClientRestartJS(t *testing.T, clientType api.Client
 		waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
 
 		// we're going to sniff calls to /sendToDevice to ensure we do NOT see a new room key being sent.
-		ch := make(chan callback.CallbackData, 10)
+		ch := make(chan callback.Data, 10)
 		mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
 		mitmConfiguration.Execute(func() {
 			// now alice is going to restart her client

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/cc"
-	"github.com/matrix-org/complement-crypto/internal/deploy"
 	"github.com/matrix-org/complement-crypto/internal/deploy/callback"
+	"github.com/matrix-org/complement-crypto/internal/deploy/mitm"
 	"github.com/matrix-org/complement/client"
 	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/must"
 )
 
-func sniffToDeviceEvent(t *testing.T, tc *cc.TestContext, ch chan callback.CallbackData) *deploy.MITMConfiguration {
+func sniffToDeviceEvent(t *testing.T, tc *cc.TestContext, ch chan callback.CallbackData) *mitm.MITMConfiguration {
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
 	mitmConfiguration.ForPath("/sendToDevice").Method("PUT").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 		if strings.Contains(cd.URL, "m.room.encrypted") {

--- a/tests/state_synchronisation_test.go
+++ b/tests/state_synchronisation_test.go
@@ -38,7 +38,7 @@ func testSigkillBeforeKeysUploadResponseRust(t *testing.T, clientType api.Client
 	tc := Instance().CreateTestContext(t, clientType, clientType)
 
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.Data) *callback.Response {
 		if terminated.Load() {
 			// make sure the 2nd upload 200 OKs
 			if cd.ResponseCode != 200 {
@@ -99,7 +99,7 @@ func testSigkillBeforeKeysUploadResponseJS(t *testing.T, clientType api.ClientTy
 	seenSecondKeysUploadWaiter := helpers.NewWaiter()
 	tc := Instance().CreateTestContext(t, clientType, clientType)
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.Data) *callback.Response {
 		if cd.Method == "OPTIONS" {
 			return nil // ignore CORS
 		}

--- a/tests/state_synchronisation_test.go
+++ b/tests/state_synchronisation_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/cc"
-	"github.com/matrix-org/complement-crypto/internal/deploy"
+	"github.com/matrix-org/complement-crypto/internal/deploy/callback"
 	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/helpers"
 )
@@ -38,7 +38,7 @@ func testSigkillBeforeKeysUploadResponseRust(t *testing.T, clientType api.Client
 	tc := Instance().CreateTestContext(t, clientType, clientType)
 
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 		if terminated.Load() {
 			// make sure the 2nd upload 200 OKs
 			if cd.ResponseCode != 200 {
@@ -99,7 +99,7 @@ func testSigkillBeforeKeysUploadResponseJS(t *testing.T, clientType api.ClientTy
 	seenSecondKeysUploadWaiter := helpers.NewWaiter()
 	tc := Instance().CreateTestContext(t, clientType, clientType)
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+	mitmConfiguration.ForPath("/keys/upload").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 		if cd.Method == "OPTIONS" {
 			return nil // ignore CORS
 		}

--- a/tests/to_device_test.go
+++ b/tests/to_device_test.go
@@ -128,7 +128,7 @@ func testUnprocessedToDeviceMessagesArentLostOnRestartRust(t *testing.T, tc *cc.
 	// sniff /sync traffic
 	waitForRoomKey := helpers.NewWaiter()
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/sync").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+	mitmConfiguration.ForPath("/sync").Listen(func(cd callback.Data) *callback.Response {
 		// When /sync shows a to-device message from Alice (indicating the room key), then SIGKILL Bob.
 		t.Logf("/sync => %v", string(cd.ResponseBody))
 		body := gjson.ParseBytes(cd.ResponseBody)
@@ -187,7 +187,7 @@ func testUnprocessedToDeviceMessagesArentLostOnRestartJS(t *testing.T, tc *cc.Te
 	// sniff /sync traffic
 	waitForRoomKey := helpers.NewWaiter()
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/sync").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+	mitmConfiguration.ForPath("/sync").Listen(func(cd callback.Data) *callback.Response {
 		// When /sync shows a to-device message from Alice (indicating the room key) then SIGKILL Bob.
 		body := gjson.ParseBytes(cd.ResponseBody)
 		toDeviceEvents := body.Get("to_device.events").Array() // Sync v2 form
@@ -274,7 +274,7 @@ func TestToDeviceMessagesAreBatched(t *testing.T) {
 		tc.WithAliceSyncing(t, func(alice api.Client) {
 			// intercept /sendToDevice and check we are sending 100 messages per request
 			mitmConfiguration := tc.Deployment.MITM().Configure(t)
-			mitmConfiguration.ForPath("/sendToDevice").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+			mitmConfiguration.ForPath("/sendToDevice").Listen(func(cd callback.Data) *callback.Response {
 				if cd.Method != "PUT" {
 					return nil
 				}
@@ -344,7 +344,7 @@ func TestToDeviceMessagesArentLostWhenKeysQueryFails(t *testing.T) {
 			bobAccessToken := bob.CurrentAccessToken(t)
 			t.Logf("Bob's token => %s", bobAccessToken)
 			mitmConfiguration := tc.Deployment.MITM().Configure(t)
-			mitmConfiguration.ForPath("/keys/query").AccessToken(bobAccessToken).BlockRequest(3, http.StatusGatewayTimeout).Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
+			mitmConfiguration.ForPath("/keys/query").AccessToken(bobAccessToken).BlockRequest(3, http.StatusGatewayTimeout).Listen(func(cd callback.Data) *callback.Response {
 				t.Logf("%+v", cd)
 				waiter.Finish()
 				return nil
@@ -414,7 +414,7 @@ func TestToDeviceMessagesAreProcessedInOrder(t *testing.T) {
 			Body string
 		}{}
 		tc.WithAliceSyncing(t, func(alice api.Client) {
-			callback := func(cd callback.CallbackData) *callback.CallbackResponse {
+			callback := func(cd callback.Data) *callback.Response {
 				// try v2 sync then SS
 				toDeviceEvents := gjson.ParseBytes(cd.ResponseBody).Get("to_device.events").Array()
 				if len(toDeviceEvents) == 0 {

--- a/tests/to_device_test.go
+++ b/tests/to_device_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/cc"
-	"github.com/matrix-org/complement-crypto/internal/deploy"
+	"github.com/matrix-org/complement-crypto/internal/deploy/callback"
 	"github.com/matrix-org/complement/helpers"
 	"github.com/matrix-org/complement/must"
 	"github.com/tidwall/gjson"
@@ -128,7 +128,7 @@ func testUnprocessedToDeviceMessagesArentLostOnRestartRust(t *testing.T, tc *cc.
 	// sniff /sync traffic
 	waitForRoomKey := helpers.NewWaiter()
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/sync").Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+	mitmConfiguration.ForPath("/sync").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 		// When /sync shows a to-device message from Alice (indicating the room key), then SIGKILL Bob.
 		t.Logf("/sync => %v", string(cd.ResponseBody))
 		body := gjson.ParseBytes(cd.ResponseBody)
@@ -187,7 +187,7 @@ func testUnprocessedToDeviceMessagesArentLostOnRestartJS(t *testing.T, tc *cc.Te
 	// sniff /sync traffic
 	waitForRoomKey := helpers.NewWaiter()
 	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/sync").Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+	mitmConfiguration.ForPath("/sync").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 		// When /sync shows a to-device message from Alice (indicating the room key) then SIGKILL Bob.
 		body := gjson.ParseBytes(cd.ResponseBody)
 		toDeviceEvents := body.Get("to_device.events").Array() // Sync v2 form
@@ -274,7 +274,7 @@ func TestToDeviceMessagesAreBatched(t *testing.T) {
 		tc.WithAliceSyncing(t, func(alice api.Client) {
 			// intercept /sendToDevice and check we are sending 100 messages per request
 			mitmConfiguration := tc.Deployment.MITM().Configure(t)
-			mitmConfiguration.ForPath("/sendToDevice").Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+			mitmConfiguration.ForPath("/sendToDevice").Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 				if cd.Method != "PUT" {
 					return nil
 				}
@@ -344,7 +344,7 @@ func TestToDeviceMessagesArentLostWhenKeysQueryFails(t *testing.T) {
 			bobAccessToken := bob.CurrentAccessToken(t)
 			t.Logf("Bob's token => %s", bobAccessToken)
 			mitmConfiguration := tc.Deployment.MITM().Configure(t)
-			mitmConfiguration.ForPath("/keys/query").AccessToken(bobAccessToken).BlockRequest(3, http.StatusGatewayTimeout).Listen(func(cd deploy.CallbackData) *deploy.CallbackResponse {
+			mitmConfiguration.ForPath("/keys/query").AccessToken(bobAccessToken).BlockRequest(3, http.StatusGatewayTimeout).Listen(func(cd callback.CallbackData) *callback.CallbackResponse {
 				t.Logf("%+v", cd)
 				waiter.Finish()
 				return nil
@@ -414,7 +414,7 @@ func TestToDeviceMessagesAreProcessedInOrder(t *testing.T) {
 			Body string
 		}{}
 		tc.WithAliceSyncing(t, func(alice api.Client) {
-			callback := func(cd deploy.CallbackData) *deploy.CallbackResponse {
+			callback := func(cd callback.CallbackData) *callback.CallbackResponse {
 				// try v2 sync then SS
 				toDeviceEvents := gjson.ParseBytes(cd.ResponseBody).Get("to_device.events").Array()
 				if len(toDeviceEvents) == 0 {


### PR DESCRIPTION
The MITM API is undergoing a refactor so #68 can be closed for good.

The first step is to move out callback and mitm code to their own packages. This is for a few reasons:
 - keeps the `deploy` package from getting too large,
 - allows more concise readable names e.g `deploy.MITMClient` vs `mitm.Client` and `deploy.CallbackResponse` vs `callback.Response`,
 - reduces circular dependencies as Go disallows circular imports. As a result, the `callback` package depends on no other complement-crypto package and is a leaf dependency. `mitm` requires the `callback` package to set up the MITM configuration. `deploy` requires both `mitm` and `callback`.

Reviewable commit-by-commit.