### PR TITLE
Add 3 helper APIs on top of MITM callbacks

### DIFF
--- a/internal/deploy/callback/callback_addon.go
+++ b/internal/deploy/callback/callback_addon.go
@@ -252,15 +252,9 @@ func (c *ActiveChannel) Close() {
 func (c *ActiveChannel) Callback() Fn {
 	return func(d Data) *Response {
 		if c.closed.Load() {
-			fmt.Println("DEBUG: AC closed")
 			return nil // test has ended, don't send on a closed channel else we panic
 		}
-		fmt.Println("DEBUG: AC sending on recv")
 		c.recvCh <- &d
-		fmt.Println("DEBUG: AC waiting for send")
-		defer func() {
-			fmt.Println("DEBUG: AC got send")
-		}()
 		// wait for the response from the test
 		return <-c.sendCh
 	}

--- a/internal/deploy/callback/callback_addon.go
+++ b/internal/deploy/callback/callback_addon.go
@@ -298,13 +298,13 @@ func NewPassiveChannel(timeout time.Duration, blocking bool) *PassiveChannel {
 }
 
 // NewActiveChannel returns a channel which can receive and modify callback responses. The
-// timeout controls how long Recv() and Send() can wait until there is callback data before
+// timeout controls how long Recv() and Send() can wait for callback data before
 // failing.
 //
 // Channels are useful when tests want to manipulate callbacks from within an `inner`
 // function.
 func NewActiveChannel(timeout time.Duration) *ActiveChannel {
-	// An active channel is a passive channel with bits on top
+	// An active channel is a PassiveChannel plus a sending channel.
 	passive := NewPassiveChannel(timeout, true)
 	return &ActiveChannel{
 		PassiveChannel: passive,

--- a/internal/deploy/callback/callback_addon.go
+++ b/internal/deploy/callback/callback_addon.go
@@ -159,3 +159,163 @@ func NewCallbackServer(t ct.TestLike, hostnameRunningComplement string) (*Callba
 
 	return callbackServer, nil
 }
+
+// SendError returns a callback.Fn which returns the provided statusCode
+// along with a JSON error $count times, after which it lets the response
+// pass through. This is useful for testing retries.
+func SendError(count uint32, statusCode int) Fn {
+	var seen atomic.Uint32
+	return func(d Data) *Response {
+		next := seen.Add(1)
+		if next > count {
+			return nil
+		}
+		return &Response{
+			RespondStatusCode: statusCode,
+			RespondBody:       json.RawMessage(`{"error":"callback.SendError"}`),
+		}
+	}
+}
+
+// TODO: helpers for "wait for this conditional to pass then execute this code whilst blocking"
+//  - for tarpitting
+//  - for sigkilling
+
+type PassiveChannel struct {
+	recvCh  chan *Data
+	timeout time.Duration
+	closed  *atomic.Bool
+}
+
+func (c *PassiveChannel) Close() {
+	if c.closed.CompareAndSwap(false, true) {
+		close(c.recvCh)
+	}
+}
+
+// Callback returns the callback implementation used to send data to this channel.
+func (c *PassiveChannel) Callback() Fn {
+	return func(d Data) *Response {
+		if c.closed.Load() {
+			return nil // test has ended, don't send on a closed channel else we panic
+		}
+		c.recvCh <- &d
+		return nil // don't modify the response
+	}
+}
+
+// Block until this channel receives a callback.
+func (c *PassiveChannel) Recv(t ct.TestLike, msg string, args ...any) *Data {
+	t.Helper()
+	select {
+	case d := <-c.recvCh:
+		return d
+	case <-time.After(c.timeout):
+		ct.Fatalf(t, msg, args...)
+	}
+	panic("unreachable")
+}
+
+// Try to receive from the channel. Does not block. Returns nil if there is nothing
+// waiting in the channel. Useful for detecting absence of a callback.
+func (c *PassiveChannel) TryRecv(t ct.TestLike) *Data {
+	t.Helper()
+	select {
+	case d := <-c.recvCh:
+		return d
+	default:
+		return nil
+	}
+}
+
+// Chan returns a consume-only channel.
+//
+// This exists as an escape hatch for when Recv/TryRecv are insufficient, and
+// this channel needs to be used as part of a larger `select` block.
+func (c *PassiveChannel) Chan() <-chan *Data {
+	return c.recvCh
+}
+
+type ActiveChannel struct {
+	*PassiveChannel
+	sendCh chan *Response
+}
+
+func (c *ActiveChannel) Close() {
+	if c.PassiveChannel.closed.CompareAndSwap(false, true) {
+		close(c.recvCh)
+		close(c.sendCh)
+	}
+}
+
+// Callback returns the callback implementation used to send data to this channel.
+func (c *ActiveChannel) Callback() Fn {
+	return func(d Data) *Response {
+		if c.closed.Load() {
+			fmt.Println("DEBUG: AC closed")
+			return nil // test has ended, don't send on a closed channel else we panic
+		}
+		fmt.Println("DEBUG: AC sending on recv")
+		c.recvCh <- &d
+		fmt.Println("DEBUG: AC waiting for send")
+		defer func() {
+			fmt.Println("DEBUG: AC got send")
+		}()
+		// wait for the response from the test
+		return <-c.sendCh
+	}
+}
+
+// Send a callback response to this channel.
+// Fails the test if the response cannot be put
+// into the channel for $timeout time.
+func (c *ActiveChannel) Send(t ct.TestLike, res *Response) {
+	t.Helper()
+	select {
+	case c.sendCh <- res:
+		return
+	case <-time.After(c.timeout):
+		ct.Fatalf(t, "Channel.Send timed out sending the response")
+	}
+}
+
+// NewPassiveChannel returns a channel which can receive callback responses,
+// but cannot modify them. This is useful for sniffing network traffic. The
+// timeout controls how long Recv() can wait until there is callback data before
+// failing. If blocking is true, callbacks will not return until Recv() is called.
+// This can be useful for synchronising actions when a callback is invoked.
+//
+// Channels are useful when tests want to manipulate callbacks from within an `inner`
+// function.
+func NewPassiveChannel(timeout time.Duration, blocking bool) *PassiveChannel {
+	// passive channels can be non-blocking as there is nothing to pair up,
+	// so let there be at most 10 callbacks in-flight at any one time.
+	// If this is too low then concurrent callbacks will block each other.
+	// If this is too high then we consume needless amounts of memory.
+	buffer := 10
+	if blocking {
+		buffer = 0
+	}
+	return &PassiveChannel{
+		timeout: timeout,
+		recvCh:  make(chan *Data, buffer),
+		closed:  &atomic.Bool{},
+	}
+}
+
+// NewActiveChannel returns a channel which can receive and modify callback responses. The
+// timeout controls how long Recv() and Send() can wait until there is callback data before
+// failing.
+//
+// Channels are useful when tests want to manipulate callbacks from within an `inner`
+// function.
+func NewActiveChannel(timeout time.Duration) *ActiveChannel {
+	// An active channel is a passive channel with bits on top
+	passive := NewPassiveChannel(timeout, true)
+	return &ActiveChannel{
+		PassiveChannel: passive,
+		// active channels need to be blocking to pair up requests/responses,
+		// so set the buffer size to 0 (blocking).
+		sendCh: make(chan *Response),
+	}
+}

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -25,6 +25,7 @@ func sniffToDeviceEvent(t *testing.T, tc *cc.TestContext, inner func(pc *callbac
 		},
 		ResponseCallback: func(cd callback.Data) *callback.Response {
 			// only invoke the callback for encrypted to-device events
+			// we can't decrypt this, but we know that this should most likely be the m.room_key to-device event.
 			if strings.Contains(cd.URL, "m.room.encrypted") {
 				return passiveChannel.Callback()(cd)
 			}

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -16,16 +16,24 @@ import (
 	"github.com/matrix-org/complement/must"
 )
 
-func sniffToDeviceEvent(t *testing.T, tc *cc.TestContext, ch chan callback.Data) *mitm.Configuration {
-	mitmConfiguration := tc.Deployment.MITM().Configure(t)
-	mitmConfiguration.ForPath("/sendToDevice").Method("PUT").Listen(func(cd callback.Data) *callback.Response {
-		if strings.Contains(cd.URL, "m.room.encrypted") {
-			// we can't decrypt this, but we know that this should most likely be the m.room_key to-device event.
-			ch <- cd
-		}
-		return nil
+func sniffToDeviceEvent(t *testing.T, tc *cc.TestContext, inner func(pc *callback.PassiveChannel)) {
+	passiveChannel := callback.NewPassiveChannel(5*time.Second, false)
+	tc.Deployment.MITM().Configure(t).WithIntercept(mitm.InterceptOpts{
+		Filter: mitm.FilterParams{
+			PathContains: "/sendToDevice",
+			Method:       "PUT",
+		},
+		ResponseCallback: func(cd callback.Data) *callback.Response {
+			// only invoke the callback for encrypted to-device events
+			if strings.Contains(cd.URL, "m.room.encrypted") {
+				return passiveChannel.Callback()(cd)
+			}
+			return nil
+		},
+	}, func() {
+		inner(passiveChannel)
+		passiveChannel.Close()
 	})
-	return mitmConfiguration
 }
 
 // This test ensures we change the m.room_key when a device leaves an E2EE room.
@@ -58,16 +66,10 @@ func TestRoomKeyIsCycledOnDeviceLogout(t *testing.T) {
 			alice.SendMessage(t, roomID, wantMsgBody)
 			waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
 			waiter2.Waitf(t, 5*time.Second, "alice2 did not see alice's message")
+			alice2StopSyncing()
 
 			// we're going to sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.Data, 10)
-			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
-
-			alice2StopSyncing()
-			// we don't know when the new room key will be sent, it could be sent as soon as the device list update
-			// is sent, or it could be delayed until message send. We want to handle both cases so we start sniffing
-			// traffic now.
-			mitmConfiguration.Execute(func() {
+			sniffToDeviceEvent(t, tc, func(pc *callback.PassiveChannel) {
 				// now alice2 is going to logout, causing her user ID to appear in device_lists.changed which
 				// should cause a /keys/query request, resulting in the client realising the device is gone,
 				// which should trigger a new room key to be sent (on message send)
@@ -81,15 +83,12 @@ func TestRoomKeyIsCycledOnDeviceLogout(t *testing.T) {
 				waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 				alice.SendMessage(t, roomID, wantMsgBody)
 				waiter.Waitf(t, 5*time.Second, "bob did not see alice's new message")
-			})
 
-			// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
-			// the room key.
-			select {
-			case <-ch:
-			default:
-				ct.Fatalf(t, "did not see /sendToDevice when logging out and sending a new message")
-			}
+				// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
+				// the room key. We can't actually inspect the event itself, so just the fact we see the
+				// encrypted to-device event is enough. Recv will timeout if we don't see it.
+				pc.Recv(t, "did not see /sendToDevice event")
+			})
 		})
 	})
 }
@@ -127,9 +126,7 @@ func TestRoomKeyIsCycledAfterEnoughMessages(t *testing.T) {
 			}
 
 			// Sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.Data, 10)
-			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
-			mitmConfiguration.Execute(func() {
+			sniffToDeviceEvent(t, tc, func(pc *callback.PassiveChannel) {
 				// When we send two messages (one to hit the threshold and one to pass it)
 				//
 				// Note that we deliberately cover two possible valid behaviours
@@ -147,15 +144,10 @@ func TestRoomKeyIsCycledAfterEnoughMessages(t *testing.T) {
 				waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 				alice.SendMessage(t, roomID, wantMsgBody)
 				waiter.Waitf(t, 5*time.Second, "bob did not see alice's message '%s'", wantMsgBody)
-			})
 
-			// Then we did send out new keys
-			select {
-			case <-ch:
-				// Success - keys were sent
-			default:
-				ct.Fatalf(t, "did not see /sendToDevice after sending rotation_period_msgs messages")
-			}
+				// Then we did send out new keys
+				pc.Recv(t, "did not see /sendToDevice after sending rotation_period_msgs messages")
+			})
 		})
 	})
 }
@@ -207,9 +199,7 @@ func TestRoomKeyIsCycledAfterEnoughTime(t *testing.T) {
 			waiter.Waitf(t, 5*time.Second, "Did not see 'before we start' event in the room")
 
 			// Sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.Data, 10)
-			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
-			mitmConfiguration.Execute(func() {
+			sniffToDeviceEvent(t, tc, func(pc *callback.PassiveChannel) {
 				// Send a message to ensure the room is working, and any timer is set up
 				wantMsgBody := "Before the time expires"
 				waiter := bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
@@ -224,15 +214,9 @@ func TestRoomKeyIsCycledAfterEnoughTime(t *testing.T) {
 				waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 				alice.SendMessage(t, roomID, wantMsgBody)
 				waiter.Waitf(t, 5*time.Second, "Did not see 'after the time expires' event in the room")
-			})
 
-			// Then we sent out new keys because the rotation timer had expired
-			select {
-			case <-ch:
-				// Success - keys were sent
-			default:
-				ct.Fatalf(t, "did not see /sendToDevice after waiting rotation_period_ms milliseconds")
-			}
+				pc.Recv(t, "did not see /sendToDevice after waiting rotation_period_ms milliseconds")
+			})
 		})
 	})
 }
@@ -262,14 +246,8 @@ func TestRoomKeyIsCycledOnMemberLeaving(t *testing.T) {
 			waiter2.Waitf(t, 5*time.Second, "charlie did not see alice's message")
 
 			// we're going to sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.Data, 10)
-			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
-
-			// we don't know when the new room key will be sent, it could be sent as soon as the device list update
-			// is sent, or it could be delayed until message send. We want to handle both cases so we start sniffing
-			// traffic now.
-			mitmConfiguration.Execute(func() {
-				// now Charlie is going to leave the room, causing her user ID to appear in device_lists.left
+			sniffToDeviceEvent(t, tc, func(pc *callback.PassiveChannel) {
+				// now Charlie is going to leave the room, causing his user ID to appear in device_lists.left
 				// which should trigger a new room key to be sent (on message send)
 				tc.Charlie.MustDo(t, "POST", []string{"_matrix", "client", "v3", "rooms", roomID, "leave"}, client.WithJSONBody(t, map[string]any{}))
 
@@ -281,15 +259,11 @@ func TestRoomKeyIsCycledOnMemberLeaving(t *testing.T) {
 				waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 				alice.SendMessage(t, roomID, wantMsgBody)
 				waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
-			})
 
-			// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
-			// the room key.
-			select {
-			case <-ch:
-			default:
-				ct.Fatalf(t, "did not see /sendToDevice when logging out and sending a new message")
-			}
+				// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
+				// the room key.
+				pc.Recv(t, "did not see /sendToDevice when logging out and sending a new message")
+			})
 		})
 	})
 }
@@ -312,16 +286,11 @@ func TestRoomKeyIsNotCycled(t *testing.T) {
 			waiter := bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 			alice.SendMessage(t, roomID, wantMsgBody)
 			waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
-
-			// we're going to sniff calls to /sendToDevice to ensure we see the new room key being sent.
-			ch := make(chan callback.Data, 10)
-			mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
-
 			t.Run("on display name change", func(t *testing.T) {
 				// we don't know when the new room key will be sent, it could be sent as soon as the device list update
 				// is sent, or it could be delayed until message send. We want to handle both cases so we start sniffing
 				// traffic now.
-				mitmConfiguration.Execute(func() {
+				sniffToDeviceEvent(t, tc, func(pc *callback.PassiveChannel) {
 					// now Bob is going to change their display name
 					// which should NOT trigger a new room key to be sent (on message send)
 					tc.Bob.MustDo(t, "PUT", []string{"_matrix", "client", "v3", "profile", tc.Bob.UserID, "displayname"}, client.WithJSONBody(t, map[string]any{
@@ -336,15 +305,12 @@ func TestRoomKeyIsNotCycled(t *testing.T) {
 					waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 					alice.SendMessage(t, roomID, wantMsgBody)
 					waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
-				})
 
-				// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
-				// the room key.
-				select {
-				case <-ch:
-					ct.Fatalf(t, "saw /sendToDevice when changing display name and sending a new message")
-				default:
-				}
+					got := pc.TryRecv(t)
+					if got != nil {
+						ct.Fatalf(t, "saw /sendToDevice when changing display name and sending a new message")
+					}
+				})
 			})
 			t.Run("on new device login", func(t *testing.T) {
 				if clientTypeA.HS == "hs2" || clientTypeB.HS == "hs2" {
@@ -354,7 +320,7 @@ func TestRoomKeyIsNotCycled(t *testing.T) {
 				// we don't know when the new room key will be sent, it could be sent as soon as the device list update
 				// is sent, or it could be delayed until message send. We want to handle both cases so we start sniffing
 				// traffic now.
-				mitmConfiguration.Execute(func() {
+				sniffToDeviceEvent(t, tc, func(pc *callback.PassiveChannel) {
 					// now Bob is going to login on a new device
 					// which should NOT trigger a new room key to be sent (on message send)
 					csapiBob2 := tc.MustRegisterNewDevice(t, tc.Bob, "OTHER_DEVICE")
@@ -373,42 +339,40 @@ func TestRoomKeyIsNotCycled(t *testing.T) {
 					waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 					alice.SendMessage(t, roomID, wantMsgBody)
 					waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
-				})
 
-				// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
-				// the room key.
+					// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
+					// the room key.
+				Consume:
+					for { // consume all items in the channel
+						// the logic here is a bit weird because we DO expect some /sendToDevice calls as Alice and Bob
+						// share the room key with Bob2. However, Alice, who is sending the message, should NOT be sending
+						// to-device msgs to Bob, as that would indicate a new exchange of room keys. To do this, we use
+						// the access token to see who the sender is, and check the request body to see who the receiver is,
+						// and make sure it's all what we expect.
+						select {
+						case sendToDevice := <-pc.Chan():
+							cli := tc.Deployment.Deployment.UnauthenticatedClient(t, "hs1")
+							cli.AccessToken = sendToDevice.AccessToken
+							whoami := cli.MustDo(t, "GET", []string{"_matrix", "client", "v3", "account", "whoami"})
+							sender := must.ParseJSON(t, whoami.Body).Get("user_id").Str
+							reqBody := struct {
+								Messages map[string]map[string]any
+							}{}
+							must.NotError(t, "failed to unmarshal intercepted request body", json.Unmarshal(sendToDevice.RequestBody, &reqBody))
 
-			Consume:
-				for { // consume all items in the channel
-					// the logic here is a bit weird because we DO expect some /sendToDevice calls as Alice and Bob
-					// share the room key with Bob2. However, Alice, who is sending the message, should NOT be sending
-					// to-device msgs to Bob, as that would indicate a new exchange of room keys. To do this, we use
-					// the access token to see who the sender is, and check the request body to see who the receiver is,
-					// and make sure it's all what we expect.
-					select {
-					case sendToDevice := <-ch:
-						cli := tc.Deployment.Deployment.UnauthenticatedClient(t, "hs1")
-						cli.AccessToken = sendToDevice.AccessToken
-						whoami := cli.MustDo(t, "GET", []string{"_matrix", "client", "v3", "account", "whoami"})
-						sender := must.ParseJSON(t, whoami.Body).Get("user_id").Str
-						reqBody := struct {
-							Messages map[string]map[string]any
-						}{}
-						must.NotError(t, "failed to unmarshal intercepted request body", json.Unmarshal(sendToDevice.RequestBody, &reqBody))
-
-						for target := range reqBody.Messages {
-							for targetDeviceID := range reqBody.Messages[target] {
-								t.Logf("%s /sendToDevice to %v (%v)", sender, target, targetDeviceID)
-								if sender == alice.UserID() && target == bob.UserID() && targetDeviceID != "OTHER_DEVICE" {
-									ct.Fatalf(t, "saw Alice /sendToDevice to Bob for old device, implying room keys were refreshed")
+							for target := range reqBody.Messages {
+								for targetDeviceID := range reqBody.Messages[target] {
+									t.Logf("%s /sendToDevice to %v (%v)", sender, target, targetDeviceID)
+									if sender == alice.UserID() && target == bob.UserID() && targetDeviceID != "OTHER_DEVICE" {
+										ct.Fatalf(t, "saw Alice /sendToDevice to Bob for old device, implying room keys were refreshed")
+									}
 								}
 							}
+						default:
+							break Consume
 						}
-
-					default:
-						break Consume
 					}
-				}
+				})
 			})
 		})
 	})
@@ -463,9 +427,7 @@ func testRoomKeyIsNotCycledOnClientRestartRust(t *testing.T, clientType api.Clie
 		// Now recreate the same client and make sure we don't send new room keys.
 
 		// we're going to sniff calls to /sendToDevice to ensure we do NOT see a new room key being sent.
-		ch := make(chan callback.Data, 10)
-		mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
-		mitmConfiguration.Execute(func() {
+		sniffToDeviceEvent(t, tc, func(pc *callback.PassiveChannel) {
 			// login as alice
 			alice := tc.MustLoginClient(t, &cc.ClientCreationRequest{
 				User: tc.Alice,
@@ -485,15 +447,14 @@ func testRoomKeyIsNotCycledOnClientRestartRust(t *testing.T, clientType api.Clie
 			waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasBody(wantMsgBody))
 			alice.SendMessage(t, roomID, wantMsgBody)
 			waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
-		})
 
-		// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
-		// the room key.
-		select {
-		case <-ch:
-			ct.Fatalf(t, "saw /sendToDevice when restarting the client and sending a new message")
-		default:
-		}
+			// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
+			// the room key.
+			got := pc.TryRecv(t)
+			if got != nil {
+				ct.Fatalf(t, "saw /sendToDevice when restarting the client and sending a new message")
+			}
+		})
 	})
 }
 
@@ -526,9 +487,7 @@ func testRoomKeyIsNotCycledOnClientRestartJS(t *testing.T, clientType api.Client
 		waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
 
 		// we're going to sniff calls to /sendToDevice to ensure we do NOT see a new room key being sent.
-		ch := make(chan callback.Data, 10)
-		mitmConfiguration := sniffToDeviceEvent(t, tc, ch)
-		mitmConfiguration.Execute(func() {
+		sniffToDeviceEvent(t, tc, func(pc *callback.PassiveChannel) {
 			// now alice is going to restart her client
 			aliceStopSyncing()
 			alice.Close(t)
@@ -543,14 +502,13 @@ func testRoomKeyIsNotCycledOnClientRestartJS(t *testing.T, clientType api.Client
 				alice.SendMessage(t, roomID, wantMsgBody)
 				waiter.Waitf(t, 5*time.Second, "bob did not see alice's message")
 			})
-		})
 
-		// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
-		// the room key.
-		select {
-		case <-ch:
-			ct.Fatalf(t, "saw /sendToDevice when restarting the client and sending a new message")
-		default:
-		}
+			// we should have seen a /sendToDevice call by now. If we didn't, this implies we didn't cycle
+			// the room key.
+			got := pc.TryRecv(t)
+			if got != nil {
+				ct.Fatalf(t, "saw /sendToDevice when restarting the client and sending a new message")
+			}
+		})
 	})
 }


### PR DESCRIPTION
Part of https://github.com/matrix-org/complement-crypto/issues/68

These helper APIs all have proven needs in existing tests, and this commit converts at least 1 test for each type of helper API to demonstrate how they can be used.

- `callback.SendError`: the simplest of the new APIs. This sends an HTTP error instead of the response a configurable number of times, after which point it passes the response through. Useful for testing that clients retry endpoints.
- `callback.PassiveChannel`: this sniffs callback data and sends it on a buffered (non-blocking) or unbuffered (blocking) channel. Useful for testing that the client sent a request.
- `callback.ActiveChannel`: this is a passive channel but it also allows responses to be sent back for each intercepted callback. As such, it is always an unbuffered (blocking) channel. Useful for performing an action when the test sees a certain callback.

Channels exist to reduce the amount of concurrent code that needs to be written for each test. It does this by:
 - providing synchronisation points,
 - with built-in timeouts,
 - and handles common channel gotchas (e.g sending on a closed channel panics)

Tests _can_ just using normal Go `chan`, but then they will need to reimplement these things for each test.

A good example of how this can simplify code is to look at how this PR changes `testUnprocessedToDeviceMessagesArentLostOnRestartJS` which closes the client when it detects a `/sync` response. Previously, we needed 2 additional goroutines and multiple waiters to synchronise between them. Using a single `ActiveChannel`, we only need 1 additional goroutine (to call `StartSyncing()` as that blocks) and _that's it_. The channel manages the synchronisation between the callback goroutine and the test goroutine, meaning the test goroutine itself can manage checking the callback data, whereas this had to be done in the callback goroutine before. It is always preferable for the main test goroutine (the goroutine running `TestWhatever`) to deal with data, as that means the test needs no additional synchronisation primitives to control access to that data.