### PR TITLE
Update js-sdk import

### DIFF
--- a/internal/api/js/js-sdk/index.html
+++ b/internal/api/js/js-sdk/index.html
@@ -12,7 +12,7 @@
     window.VerifierEvent = VerifierEvent;
     import { CryptoEvent } from "matrix-js-sdk/src/crypto";
     window.CryptoEvent = CryptoEvent;
-    import * as sdk from "matrix-js-sdk";
+    import * as sdk from "matrix-js-sdk/src/index";
     window.matrix = sdk;
     import { IndexedDBStore, IndexedDBCryptoStore } from "matrix-js-sdk/src/matrix";
     window.IndexedDBCryptoStore = IndexedDBCryptoStore;


### PR DESCRIPTION
Without this, we won't be able to run complement-crypto against an unbuilt js-sdk (ie, a js-sdk which has been checked out from git but not yet `yarn build`-ed).

Arguably, we should import from the proper entry points, since that gives a more representative test of how matrix-js-sdk is *meant* to be used. But that involves adding a `yarn build` to the CI somewhere and I don't have the energy for that right now.