### PR TITLE
fix(api): Use the new sliding sync version API from the Rust SDK

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -64,7 +64,10 @@ type RustClient struct {
 func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, error) {
 	t.Logf("NewRustClient[%s][%s] creating...", opts.UserID, opts.DeviceID)
 	matrix_sdk_ffi.LogEvent("rust.go", &zero, matrix_sdk_ffi.LogLevelInfo, t.Name(), fmt.Sprintf("NewRustClient[%s][%s] creating...", opts.UserID, opts.DeviceID))
-	ab := matrix_sdk_ffi.NewClientBuilder().HomeserverUrl(opts.BaseURL).SlidingSyncProxy(&opts.SlidingSyncURL).AutoEnableCrossSigning(true)
+	ab := matrix_sdk_ffi.NewClientBuilder()
+		.HomeserverUrl(opts.BaseURL)
+		.SlidingSyncVersionBuilder(&matrix_sdk_ffi.SlidingSyncVersionBuilderProxy{ Url: &opts.SlidingSyncURL })
+		.AutoEnableCrossSigning(true)
 	var clientSessionDelegate matrix_sdk_ffi.ClientSessionDelegate
 	if opts.EnableCrossProcessRefreshLockProcessName != "" {
 		t.Logf("enabling cross process refresh lock with proc name=%s", opts.EnableCrossProcessRefreshLockProcessName)

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -64,10 +64,11 @@ type RustClient struct {
 func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, error) {
 	t.Logf("NewRustClient[%s][%s] creating...", opts.UserID, opts.DeviceID)
 	matrix_sdk_ffi.LogEvent("rust.go", &zero, matrix_sdk_ffi.LogLevelInfo, t.Name(), fmt.Sprintf("NewRustClient[%s][%s] creating...", opts.UserID, opts.DeviceID))
-	ab := matrix_sdk_ffi.NewClientBuilder()
-		.HomeserverUrl(opts.BaseURL)
-		.SlidingSyncVersionBuilder(&matrix_sdk_ffi.SlidingSyncVersionBuilderProxy{ Url: &opts.SlidingSyncURL })
-		.AutoEnableCrossSigning(true)
+	slidingSyncVersion := matrix_sdk_ffi.SlidingSyncVersionBuilderProxy{Url: opts.SlidingSyncURL}
+	ab := matrix_sdk_ffi.NewClientBuilder().
+		HomeserverUrl(opts.BaseURL).
+		SlidingSyncVersionBuilder(&slidingSyncVersion).
+		AutoEnableCrossSigning(true)
 	var clientSessionDelegate matrix_sdk_ffi.ClientSessionDelegate
 	if opts.EnableCrossProcessRefreshLockProcessName != "" {
 		t.Logf("enabling cross process refresh lock with proc name=%s", opts.EnableCrossProcessRefreshLockProcessName)
@@ -93,11 +94,11 @@ func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, erro
 	}
 	if opts.AccessToken != "" { // restore the session
 		session := matrix_sdk_ffi.Session{
-			AccessToken:      opts.AccessToken,
-			UserId:           opts.UserID,
-			DeviceId:         opts.DeviceID,
-			HomeserverUrl:    opts.BaseURL,
-			SlidingSyncProxy: &opts.SlidingSyncURL,
+			AccessToken:        opts.AccessToken,
+			UserId:             opts.UserID,
+			DeviceId:           opts.DeviceID,
+			HomeserverUrl:      opts.BaseURL,
+			SlidingSyncVersion: &slidingSyncVersion,
 		}
 		if err := client.RestoreSession(session); err != nil {
 			return nil, fmt.Errorf("RestoreSession: %s", err)

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -94,11 +94,13 @@ func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, erro
 	}
 	if opts.AccessToken != "" { // restore the session
 		session := matrix_sdk_ffi.Session{
-			AccessToken:        opts.AccessToken,
-			UserId:             opts.UserID,
-			DeviceId:           opts.DeviceID,
-			HomeserverUrl:      opts.BaseURL,
-			SlidingSyncVersion: slidingSyncVersion,
+			AccessToken:   opts.AccessToken,
+			UserId:        opts.UserID,
+			DeviceId:      opts.DeviceID,
+			HomeserverUrl: opts.BaseURL,
+			SlidingSyncVersion: matrix_sdk_ffi.SlidingSyncVersionProxy{
+				Url: opts.SlidingSyncURL,
+			},
 		}
 		if err := client.RestoreSession(session); err != nil {
 			return nil, fmt.Errorf("RestoreSession: %s", err)

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -67,7 +67,7 @@ func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, erro
 	slidingSyncVersion := matrix_sdk_ffi.SlidingSyncVersionBuilderProxy{Url: opts.SlidingSyncURL}
 	ab := matrix_sdk_ffi.NewClientBuilder().
 		HomeserverUrl(opts.BaseURL).
-		SlidingSyncVersionBuilder(&slidingSyncVersion).
+		SlidingSyncVersionBuilder(slidingSyncVersion).
 		AutoEnableCrossSigning(true)
 	var clientSessionDelegate matrix_sdk_ffi.ClientSessionDelegate
 	if opts.EnableCrossProcessRefreshLockProcessName != "" {

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -98,7 +98,7 @@ func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, erro
 			UserId:             opts.UserID,
 			DeviceId:           opts.DeviceID,
 			HomeserverUrl:      opts.BaseURL,
-			SlidingSyncVersion: &slidingSyncVersion,
+			SlidingSyncVersion: slidingSyncVersion,
 		}
 		if err := client.RestoreSession(session); err != nil {
 			return nil, fmt.Errorf("RestoreSession: %s", err)


### PR DESCRIPTION
Anticipating the merge of https://github.com/matrix-org/matrix-rust-sdk/pull/3889. The configuration of sliding sync on the `Client` has changed. This patch updates this project to match this change.

Please wait for the PR on `matrix-rust-sdk` to be merged before merging this one.