### PR TITLE
Adapt the `rust.go` code to the changes in FFI bindings

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -909,20 +909,17 @@ func timelineItemToEvent(item *matrix_sdk_ffi.TimelineItem) *api.Event {
 	return eventTimelineItemToEvent(*ev)
 }
 
-func eventTimelineItemToEvent(item *matrix_sdk_ffi.EventTimelineItem) *api.Event {
-	if item == nil {
-		return nil
-	}
+func eventTimelineItemToEvent(item matrix_sdk_ffi.EventTimelineItem) *api.Event {
 	eventID := ""
-	if item.EventId() != nil {
-		eventID = *item.EventId()
+	if item.EventId != nil {
+		eventID = *item.EventId
 	}
 	complementEvent := api.Event{
 		ID:     eventID,
-		Sender: item.Sender(),
+		Sender: item.Sender,
 	}
-	switch k := item.Content().Kind().(type) {
-	case matrix_sdk_ffi.TimelineItemContentKindRoomMembership:
+	switch k := item.Content.(type) {
+	case matrix_sdk_ffi.TimelineItemContentRoomMembership:
 		complementEvent.Target = k.UserId
 		change := *k.Change
 		switch change {
@@ -949,16 +946,16 @@ func eventTimelineItemToEvent(item *matrix_sdk_ffi.EventTimelineItem) *api.Event
 		default:
 			fmt.Printf("%s unhandled membership %d\n", k.UserId, change)
 		}
-	case matrix_sdk_ffi.TimelineItemContentKindUnableToDecrypt:
+	case matrix_sdk_ffi.TimelineItemContentUnableToDecrypt:
 		complementEvent.FailedToDecrypt = true
 	}
 
-	content := item.Content()
+	content := item.Content
 	if content != nil {
-		msg := content.AsMessage()
-		if msg != nil {
-			msgg := *msg
-			complementEvent.Text = msgg.Body()
+		switch msg := content.(type) {
+		case matrix_sdk_ffi.TimelineItemContentMessage:
+
+			complementEvent.Text = msg.Content.Body
 		}
 	}
 	return &complementEvent


### PR DESCRIPTION
[This PR](https://github.com/matrix-org/matrix-rust-sdk/pull/3942)  will change how `EventTimelineItem` and other structs related to it are exposed in the bindings, effectively breaking the Go bindings used in this repo.

With these changes the tests pass again, but please let me know if there's anything wrong since I'm not very familiar with Go.