### PR TITLE
Pass in nil for the passphrase in the EnableRecovery method

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -456,7 +456,7 @@ func (c *RustClient) MustBackupKeys(t ct.TestLike) (recoveryKey string) {
 	var listener matrix_sdk_ffi.EnableRecoveryProgressListener = genericListener
 	e := c.FFIClient.Encryption()
 	defer e.Destroy()
-	recoveryKey, err := e.EnableRecovery(true, listener)
+	recoveryKey, err := e.EnableRecovery(true, nil, listener)
 	must.NotError(t, "Encryption.EnableRecovery", err)
 	for !genericListener.isClosed.Load() {
 		select {


### PR DESCRIPTION
The SDK always supported passphrases in addition to randomly generated keys for the recovery subsystem, the bindings have now started to expose this functionality as well.

Since the code-paths are the same for the passphrase based recovery mechanism we just pass in nil and continue to test the recovery subsystem using the randomly generated key.