### PR TITLE
Add missing parameter to `VerificationStateListener`

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -268,7 +268,7 @@ func (c *RustClient) RequestOwnUserVerification(t ct.TestLike) chan api.Verifica
 		container:  container,
 		ch:         ch,
 	}
-	c.FFIClient.Encryption().VerificationStateListener(delegateImpl)
+	c.FFIClient.Encryption().VerificationStateListener(delegateImpl, true)
 
 	var delegate matrix_sdk_ffi.SessionVerificationControllerDelegate = delegateImpl
 	svc.SetDelegate(&delegate)


### PR DESCRIPTION
There is a new parameter needed in this API call.