### PR TITLE
Simplify the install_uniffi_bindgen_go script

### DIFF
--- a/install_uniffi_bindgen_go.sh
+++ b/install_uniffi_bindgen_go.sh
@@ -1,6 +1,4 @@
 #!/bin/bash -e
 set -o pipefail
 
-git clone --depth 1 --branch main https://github.com/NordSecurity/uniffi-bindgen-go _temp_uniffi_bindgen_go;
-(cd _temp_uniffi_bindgen_go && git submodule init && git submodule update && cargo install uniffi-bindgen-go --path ./bindgen);
-rm -rf _temp_uniffi_bindgen_go;
+cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go


### PR DESCRIPTION
Not sure what added value the script provides now that it's a single command, let me know if you'd rather have the documentation updated to tell users to use `cargo install` directly.