### PR TITLE
js: Replace legacy imports by new crypto api

### DIFF
--- a/internal/api/js/js-sdk/index.html
+++ b/internal/api/js/js-sdk/index.html
@@ -5,12 +5,10 @@
   <script type="module">
     import { Buffer } from "buffer";
     window.Buffer = Buffer;
-    import { decodeRecoveryKey } from "matrix-js-sdk/src/crypto/recoverykey";
+    import { VerificationPhase, VerifierEvent, decodeRecoveryKey, CryptoEvent } from "matrix-js-sdk/src/crypto-api";
     window.decodeRecoveryKey = decodeRecoveryKey;
-    import { VerificationPhase, VerifierEvent } from "matrix-js-sdk/src/crypto-api/verification";
     window.VerificationPhase = VerificationPhase;
     window.VerifierEvent = VerifierEvent;
-    import { CryptoEvent } from "matrix-js-sdk/src/crypto";
     window.CryptoEvent = CryptoEvent;
     import * as sdk from "matrix-js-sdk/src/index";
     window.matrix = sdk;


### PR DESCRIPTION
The js tests are using the legacy crypto which will be removed in this [PR](https://github.com/matrix-org/matrix-js-sdk/pull/4653).
This PR replaces the legacy imports by the crypto api imports. 