### PR TITLE
fix(rust): Matrix Rust SDK has dropped support for MSC3575

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -77,7 +77,7 @@ type RustClient struct {
 func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, error) {
 	t.Logf("NewRustClient[%s][%s] creating...", opts.UserID, opts.DeviceID)
 	matrix_sdk_ffi.LogEvent("rust.go", &zero, matrix_sdk_ffi.LogLevelInfo, t.Name(), fmt.Sprintf("NewRustClient[%s][%s] creating...", opts.UserID, opts.DeviceID))
-	slidingSyncVersion := matrix_sdk_ffi.SlidingSyncVersionBuilderNative{}
+	slidingSyncVersion := matrix_sdk_ffi.SlidingSyncVersionBuilderNative
 	clientSessionDelegate := NewMemoryClientSessionDelegate()
 	ab := matrix_sdk_ffi.NewClientBuilder().
 		HomeserverUrl(opts.BaseURL).
@@ -113,7 +113,7 @@ func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, erro
 			UserId:             opts.UserID,
 			DeviceId:           opts.DeviceID,
 			HomeserverUrl:      opts.BaseURL,
-			SlidingSyncVersion: matrix_sdk_ffi.SlidingSyncVersionNative{},
+			SlidingSyncVersion: matrix_sdk_ffi.SlidingSyncVersionNative,
 		}
 		if err := client.RestoreSession(session); err != nil {
 			return nil, fmt.Errorf("RestoreSession: %s", err)


### PR DESCRIPTION
This patch should be merged once https://github.com/matrix-org/matrix-rust-sdk/pull/4531/ is merged.

`uniffi-bindgen-go` provides a different layout for `SlidingSyncVersionBuilder` since it will be a “flat” enum (it only contains simple variant, no more struct as variant).