### PR TITLE
js: Use `CryptoApi.restoreKeyBackup` instead of deprecated `MatrixClient.restoreKeyBackupWithSecretStorage`

### DIFF
--- a/internal/api/js/js.go
+++ b/internal/api/js/js.go
@@ -662,7 +662,8 @@ func (c *JSClient) LoadBackup(t ct.TestLike, recoveryKey string) error {
 		console.log("will return recovery key for default key id " + keyId);
 		const keyBackupCheck = await window.__client.getCrypto().checkKeyBackupAndEnable();
 		console.log("key backup: ", JSON.stringify(keyBackupCheck));
-		await window.__client.restoreKeyBackupWithSecretStorage(keyBackupCheck ? keyBackupCheck.backupInfo : null, undefined, undefined);`,
+		await window.__client.getCrypto().loadSessionBackupPrivateKeyFromSecretStorage();
+		await window.__client.getCrypto().restoreKeyBackup();`,
 		recoveryKey))
 	return err
 }


### PR DESCRIPTION
Replace deprecated [`MatrixClient.restoreKeybackupWithSecretstorage`](https://matrix-org.github.io/matrix-js-sdk/classes/matrix.MatrixClient.html#restorekeybackupwithsecretstorage) by [`CryptoApi.restoreKeybackup`](https://matrix-org.github.io/matrix-js-sdk/interfaces/crypto-api.CryptoApi.html#restorekeybackup-1)