### PR TITLE
Pin uniffi-bindgen-go to `v0.2.2+v0.25.0` bacause latest is failing the RustSDK

### DIFF
--- a/install_uniffi_bindgen_go.sh
+++ b/install_uniffi_bindgen_go.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 set -o pipefail
 
-cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go
+cargo install uniffi-bindgen-go --tag v0.2.2+v0.25.0 --git https://github.com/NordSecurity/uniffi-bindgen-go


### PR DESCRIPTION
- https://github.com/matrix-org/matrix-rust-sdk/actions/runs/14239463550/job/39906569970
- https://github.com/matrix-org/matrix-rust-sdk/actions/runs/14240730138/job/39910686891

```
Error: Failed to extract data from archive member `matrix_sdk_crypto-7ddca152aad197f2.matrix_sdk_crypto.5dfcdf8951dfed68-cgu.09.rcgu.o`

Caused by:
    invalid enum shape discriminant 9
```