### PR TITLE
Adapt to SDK changes in `ClientError`

### DIFF
--- a/internal/api/rust/session_delegate.go
+++ b/internal/api/rust/session_delegate.go
@@ -15,7 +15,7 @@ func NewMemoryClientSessionDelegate() *MemoryClientSessionDelegate {
 func (d *MemoryClientSessionDelegate) RetrieveSessionFromKeychain(userID string) (matrix_sdk_ffi.Session, *matrix_sdk_ffi.ClientError) {
 	s, exists := d.userIDToSession[userID]
 	if !exists {
-		return matrix_sdk_ffi.Session{}, matrix_sdk_ffi.NewClientErrorGeneric("Failed to find RestorationToken in the Keychain.")
+		return matrix_sdk_ffi.Session{}, matrix_sdk_ffi.NewClientErrorGeneric("Failed to find RestorationToken in the Keychain.", nil)
 	}
 	return s, nil
 }


### PR DESCRIPTION
It seems like there is only 1 line affected by the new `details` field.