### PR TITLE
Remove parallel testing

### DIFF
--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -169,6 +169,8 @@ jobs:
             export LIBRARY_PATH="$(pwd)$RUST_SDK_LIB_RELATIVE"
             export LD_LIBRARY_PATH="$(pwd)$RUST_SDK_LIB_RELATIVE"
             export COMPLEMENT_CRYPTO_RPC_BINARY="$(pwd)/complement-crypto/rpc"
+            docker ps
+            docker container ls
             cd complement-crypto &&
             set -o pipefail &&
             go test -v -p 1 -count=1 -json -tags=$GO_TAGS -timeout 20m ./tests ./tests/$LANG_SPECIFIC_TESTS | gotestfmt

--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -171,7 +171,7 @@ jobs:
             export COMPLEMENT_CRYPTO_RPC_BINARY="$(pwd)/complement-crypto/rpc"
             cd complement-crypto &&
             set -o pipefail &&
-            go test -v -p 2 -count=1 -json -tags=$GO_TAGS -timeout 15m ./tests ./tests/$LANG_SPECIFIC_TESTS | gotestfmt
+            go test -v -p 1 -count=1 -json -tags=$GO_TAGS -timeout 20m ./tests ./tests/$LANG_SPECIFIC_TESTS | gotestfmt
           shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
           env:
             COMPLEMENT_BASE_IMAGE: homeserver

--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -169,8 +169,8 @@ jobs:
             export LIBRARY_PATH="$(pwd)$RUST_SDK_LIB_RELATIVE"
             export LD_LIBRARY_PATH="$(pwd)$RUST_SDK_LIB_RELATIVE"
             export COMPLEMENT_CRYPTO_RPC_BINARY="$(pwd)/complement-crypto/rpc"
-            docker ps
-            docker container ls
+            docker ps --all
+            docker container ls --all
             cd complement-crypto &&
             set -o pipefail &&
             go test -v -p 1 -count=1 -json -tags=$GO_TAGS -timeout 20m ./tests ./tests/$LANG_SPECIFIC_TESTS | gotestfmt

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,20 +11,6 @@ jobs:
     if: "github.event_name == 'pull_request'"
     uses: "matrix-org/backend-meta/.github/workflows/sign-off.yml@v2"
 
-  js-latest-main:
-    name: Tests (JS only, latest)
-    uses: ./.github/workflows/single_sdk_tests.yml
-    with:
-      use_js_sdk: 'MATCHING_BRANCH'
-      use_complement_crypto: '.'
-
-  rust-latest-main:
-    name: Tests (Rust only, latest)
-    uses: ./.github/workflows/single_sdk_tests.yml
-    with:
-      use_rust_sdk: 'MATCHING_BRANCH'
-      use_complement_crypto: '.'
-
   complement:
     name: Tests
     runs-on: ubuntu-22.04
@@ -146,7 +132,7 @@ jobs:
           export LD_LIBRARY_PATH="$(pwd)/rust-sdk/target/debug"
           export COMPLEMENT_CRYPTO_RPC_BINARY="$(pwd)/rpc"
           set -o pipefail &&
-          go test -p 3 -v -json -tags='jssdk,rust' -count=1 -timeout 15m ./tests ./tests/js ./tests/rust | gotestfmt
+          go test -p 1 -v -json -tags='jssdk,rust' -count=1 -timeout 15m ./tests ./tests/js ./tests/rust | gotestfmt
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         name: Run Complement Crypto Tests
         env:


### PR DESCRIPTION
Dirty servers seem to use the same namespace, so can cause container conflicts when you run >1 test suite at the same time:
```
CreateDirtyDeployment failed: CreateDirtyServer: Failed to deploy image homeserver : Error response from daemon: Conflict. The container name "/complement_crypto_dirty_hs1" is already in use by container "ef141595c2188aa4d0ece3aa5f74fdb43a7ba276cf95a00076ad387881d7b24a". You have to remove (or rename) that container to be able to reuse that name.
```

We should be namespacing dirty servers correctly, but for now we can quickly fix this by removing concurrency.