### PR TITLE
Document LD_LIBRARY_PATH and go version requirements

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -238,7 +238,7 @@ Check out matrix-rust-sdk, edit your files and then run:
 ./rebuild_rust_sdk.sh /path/to/your/matrix-rust-sdk
 ```
 
-Make sure you launch the tests with `LIBRARY_PATH` pointing to
+Make sure you launch the tests with `LIBRARY_PATH` and `LD_LIBRARY_PATH` pointing to
 `$matrix-rust-sdk/target/debug` so that the built code gets used.
 
 Make sure you add `-count=1` on the command line when you re-run the tests,

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ It currently tests [rust SDK FFI bindings](https://github.com/matrix-org/matrix-
 *Please ensure you have met Complement's [Dependencies](https://github.com/matrix-org/complement?tab=readme-ov-file#dependencies) first.
 In practice, this means you must have `go` and `docker` installed.*
 
+As of this writing, Complement Crypto's bindings to the Rust SDK are
+incompatible with `go` 1.24 due to
+https://github.com/NordSecurity/uniffi-bindgen-go/issues/66. Use `go` 1.23 for
+now.
+
 Complement Crypto can be compiled and run in different modes depending on which SDK is being tested. For example, if you only want
 to test JS SDK then you do not need to compile rust code or run rust tests, and vice versa. Conversely, if you want to test
 interoperability between the two SDKs then you need to compile both SDKs.
@@ -64,6 +69,7 @@ To run only rust tests:
 COMPLEMENT_CRYPTO_TEST_CLIENT_MATRIX=rr \
 COMPLEMENT_BASE_IMAGE=ghcr.io/matrix-org/synapse-service:v1.114.0 \
 LIBRARY_PATH=$LIBRARY_PATH:/path/to/matrix-rust-sdk/target/debug \
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/matrix-rust-sdk/target/debug \
 go test -v -count=1 -tags=rust -timeout 15m ./tests
 ```
 

--- a/rebuild_rust_sdk.sh
+++ b/rebuild_rust_sdk.sh
@@ -56,5 +56,5 @@ uniffi-bindgen-go -o $COMPLEMENT_DIR/internal/api/rust --config $COMPLEMENT_DIR/
 cd $COMPLEMENT_DIR
 sed -i.bak 's^// #include <matrix_sdk_ffi.h>^// #include <matrix_sdk_ffi.h>\n// #cgo LDFLAGS: -lmatrix_sdk_ffi^' internal/api/rust/matrix_sdk_ffi/matrix_sdk_ffi.go
 
-echo "OK! Ensure LIBRARY_PATH is set to $RUST_SDK_DIR/target/debug so the .a/.dylib file is picked up when 'go test' is run."
-echo "e.g COMPLEMENT_BASE_IMAGE=homeserver:latest LIBRARY_PATH=\$LIBRARY_PATH:$RUST_SDK_DIR/target/debug go test ./tests"
+echo "OK! Ensure LIBRARY_PATH and LD_LIBRARY_PATH are set to $RUST_SDK_DIR/target/debug so the .so/.dylib file is picked up when 'go test' is run."
+echo "e.g COMPLEMENT_BASE_IMAGE=homeserver:latest LIBRARY_PATH=\$LIBRARY_PATH:$RUST_SDK_DIR/target/debug LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RUST_SDK_DIR/target/debug go test ./tests"


### PR DESCRIPTION
I don't know how this ever worked for anyone without setting LD_LIBRARY_PATH. It's worth noting that all the CI configurations set it.

Probably on Apple-flavoured environments you have to set something else, so corrections welcome.