### PR TITLE
Add `GetEventShield` to language bindings

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -55,6 +55,8 @@ type Client interface {
 	Backpaginate(t ct.TestLike, roomID string, count int) error
 	// GetEvent will return the client's view of this event, or returns an error if the event cannot be found.
 	GetEvent(t ct.TestLike, roomID, eventID string) (*Event, error)
+	// GetEventShield will return the "shield state" for this event, or `nil` if the event should have no shield, or an error if the event cannot be found.
+	GetEventShield(t ct.TestLike, roomID, eventID string) (*EventShield, error)
 	// BackupKeys will backup E2EE keys, else return an error.
 	BackupKeys(t ct.TestLike) (recoveryKey string, err error)
 	// LoadBackup will recover E2EE keys from the latest backup, else return an error.
@@ -364,6 +366,11 @@ type Event struct {
 	// FFI bindings don't expose type
 	Membership      string
 	FailedToDecrypt bool
+}
+
+type EventShield struct {
+	Colour string // "Red" or "Grey"
+	Code   string // "VerificationViolation" or similar
 }
 
 type Waiter interface {

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -2,6 +2,8 @@ package rust
 
 import (
 	"fmt"
+	"github.com/matrix-org/complement-crypto/internal/api/rust/matrix_sdk_common"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -336,6 +338,60 @@ func (c *RustClient) GetEvent(t ct.TestLike, roomID, eventID string) (*api.Event
 		return nil, fmt.Errorf("found timeline item %s but failed to convert it to an Event", eventID)
 	}
 	return ev, nil
+}
+
+func (c *RustClient) GetEventShield(t ct.TestLike, roomID, eventID string) (*api.EventShield, error) {
+	t.Helper()
+	room := c.findRoom(t, roomID)
+	timelineItem, err := mustGetTimeline(t, room).GetEventTimelineItemByEventId(eventID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to GetEventTimelineItemByEventId(%s): %s", eventID, err)
+	}
+	shieldState := timelineItem.LazyProvider.GetShields(false)
+
+	codeToString := func(code matrix_sdk_common.ShieldStateCode) string {
+		var result string
+		switch code {
+		case matrix_sdk_common.ShieldStateCodeAuthenticityNotGuaranteed:
+			result = "AuthenticityNotGuaranteed"
+		case matrix_sdk_common.ShieldStateCodeUnknownDevice:
+			result = "UnknownDevice"
+		case matrix_sdk_common.ShieldStateCodeUnsignedDevice:
+			result = "UnsignedDevice"
+		case matrix_sdk_common.ShieldStateCodeUnverifiedIdentity:
+			result = "UnverifiedIdentity"
+		case matrix_sdk_common.ShieldStateCodeSentInClear:
+			result = "SentInClear"
+		case matrix_sdk_common.ShieldStateCodeVerificationViolation:
+			result = "VerificationViolation"
+		default:
+			log.Panicf("Unknown shield code %d", code)
+		}
+		return result
+	}
+
+	var eventShield *api.EventShield
+
+	if shieldState != nil {
+		shield := *shieldState
+		switch shield.(type) {
+		case matrix_sdk_ffi.ShieldStateNone:
+			// no-op
+
+		case matrix_sdk_ffi.ShieldStateGrey:
+			eventShield = &api.EventShield{
+				Colour: "grey",
+				Code:   codeToString(shield.(matrix_sdk_ffi.ShieldStateGrey).Code),
+			}
+
+		case matrix_sdk_ffi.ShieldStateRed:
+			eventShield = &api.EventShield{
+				Colour: "red",
+				Code:   codeToString(shield.(matrix_sdk_ffi.ShieldStateRed).Code),
+			}
+		}
+	}
+	return eventShield, nil
 }
 
 // StartSyncing to begin syncing from sync v2 / sliding sync.

--- a/internal/deploy/rpc/client.go
+++ b/internal/deploy/rpc/client.go
@@ -294,6 +294,17 @@ func (c *RPCClient) GetEvent(t ct.TestLike, roomID, eventID string) (*api.Event,
 	return &ev, err
 }
 
+// GetEventShield will return the "shield state" for this event, or `nil` if the event should have no shield, or an error if the event cannot be found.
+func (c *RPCClient) GetEventShield(t ct.TestLike, roomID, eventID string) (*api.EventShield, error) {
+	var shield *api.EventShield
+	err := c.client.Call("Server.GetEventShield", RPCGetEvent{
+		TestName: t.Name(),
+		RoomID:   roomID,
+		EventID:  eventID,
+	}, &shield)
+	return shield, err
+}
+
 // BackupKeys will backup E2EE keys, else return an error.
 func (c *RPCClient) BackupKeys(t ct.TestLike) (recoveryKey string, err error) {
 	err = c.client.Call("Server.BackupKeys", 0, &recoveryKey)

--- a/internal/deploy/rpc/server.go
+++ b/internal/deploy/rpc/server.go
@@ -269,6 +269,17 @@ func (s *Server) GetEvent(input RPCGetEvent, output *api.Event) error {
 	return nil
 }
 
+// GetEventShield will return the "shield state" for this event, or `nil` if the event should have no shield, or an error if the event cannot be found.
+func (s *Server) GetEventShield(input RPCGetEvent, output **api.EventShield) error {
+	defer s.keepAlive()
+	shield, err := s.activeClient.GetEventShield(&api.MockT{TestName: input.TestName}, input.RoomID, input.EventID)
+	if err != nil {
+		return err
+	}
+	*output = shield
+	return nil
+}
+
 // BackupKeys will backup E2EE keys, else fail the test.
 func (s *Server) BackupKeys(testName string, recoveryKey *string) error {
 	defer s.keepAlive()


### PR DESCRIPTION
Support for checking the event shield from tests.