### PR TITLE
rust: fix build failure

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -343,8 +343,8 @@ func (c *RustClient) GetEvent(t ct.TestLike, roomID, eventID string) (*api.Event
 
 func (c *RustClient) GetEventShield(t ct.TestLike, roomID, eventID string) (*api.EventShield, error) {
 	t.Helper()
-	room := c.findRoom(t, roomID)
-	timelineItem, err := mustGetTimeline(t, room).GetEventTimelineItemByEventId(eventID)
+	_, uiTimeline := c.findRoom(t, roomID)
+	timelineItem, err := uiTimeline.GetEventTimelineItemByEventId(eventID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to GetEventTimelineItemByEventId(%s): %s", eventID, err)
 	}


### PR DESCRIPTION
#181 and #182 crossed on the wire, breaking the build. This fixes things up.