### PR TITLE
Update to latest Complement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/chromedp/chromedp v0.13.6
 	github.com/docker/docker v28.0.4+incompatible
 	github.com/docker/go-connections v0.5.0
-	github.com/matrix-org/complement v0.0.0-20250508081216-d2e04c995666
+	github.com/matrix-org/complement v0.0.0-20250606075022-5daf877cbabb
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
@@ -73,8 +73,8 @@ require (
 	go.opentelemetry.io/otel v1.30.0 // indirect
 	go.opentelemetry.io/otel/metric v1.30.0 // indirect
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
-	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
 	google.golang.org/grpc v1.64.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matrix-org/complement v0.0.0-20250508081216-d2e04c995666 h1:N3oro1D2kWgEx55YZjvwMf0Po+YTx9wfXGNacRhewNE=
 github.com/matrix-org/complement v0.0.0-20250508081216-d2e04c995666/go.mod h1:ZOp+YIUYU193+0noNtaGP4dxos0SGvjsLA1Ef+M0bnY=
+github.com/matrix-org/complement v0.0.0-20250606075022-5daf877cbabb h1:gD4ylG5g7cFt3Y6M10fVakDXvhh2Bn45xwcL1VrMjrk=
+github.com/matrix-org/complement v0.0.0-20250606075022-5daf877cbabb/go.mod h1:46S13OfQFIDaaXTKWlzUqN4KKq/Yx3MOzD6P/QKdimI=
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530 h1:kHKxCOLcHH8r4Fzarl4+Y3K5hjothkVW5z7T1dUM11U=
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20250119093516-0a1b2bafb5cf h1:NcRPAlNWXSMrYBOw9oBEX7z5uQxIKA1m/eo51DYQ7KM=
@@ -179,6 +181,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
 golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -205,6 +209,8 @@ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.28.0 h1:/Ts8HFuMR2E6IP/jlo7QVLZHggjKQbhu/7H0LJFr3Gg=
 golang.org/x/term v0.28.0/go.mod h1:Sw/lC2IAUZ92udQNf3WodGtn4k/XoLyZoh8v/8uiwek=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/matrix-org/gomatrixserverlib/spec"
 	"time"
 
 	"github.com/matrix-org/complement/client"
@@ -9,8 +10,8 @@ import (
 )
 
 type ClientType struct {
-	Lang ClientTypeLang // rust or js
-	HS   string         // hs1 or hs2
+	Lang ClientTypeLang  // rust or js
+	HS   spec.ServerName // hs1 or hs2
 }
 
 // Client represents a generic crypto client.

--- a/internal/cc/instance.go
+++ b/internal/cc/instance.go
@@ -9,6 +9,8 @@ import (
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/config"
 	"github.com/matrix-org/complement-crypto/internal/deploy"
+
+	complementconfig "github.com/matrix-org/complement/config"
 )
 
 // Instance represents a test instance.
@@ -37,7 +39,7 @@ func (i *Instance) TestMain(m *testing.M, namespace string) {
 	}
 
 	// Defer to complement to run the test suite
-	complement.TestMain(m, namespace, complement.WithCleanup(func() { // always teardown even if panicking
+	complement.TestMain(m, namespace, complement.WithCleanup(func(conf *complementconfig.Complement) { // always teardown even if panicking
 		i.ssMutex.Lock()
 		if i.ssDeployment != nil {
 			i.ssDeployment.Teardown()

--- a/internal/cc/test_context.go
+++ b/internal/cc/test_context.go
@@ -56,7 +56,7 @@ type TestContext struct {
 // This User can then be passed to other functions to login on new test devices.
 func (c *TestContext) RegisterNewUser(t *testing.T, clientType api.ClientType, localpartSuffix string) *User {
 	return &User{
-		CSAPI: c.Deployment.Register(t, clientType.HS, helpers.RegistrationOpts{
+		CSAPI: c.Deployment.Register(t, string(clientType.HS), helpers.RegistrationOpts{
 			LocalpartSuffix: localpartSuffix,
 			Password:        "complement-crypto-password",
 		}),
@@ -277,7 +277,7 @@ func (encRoomOptions) RotationPeriodMs(milliseconds int) EncRoomOption {
 
 // MustRegisterNewDevice logs in a new device for this client, else fails the test.
 func (c *TestContext) MustRegisterNewDevice(t *testing.T, user *User, newDeviceID string) *User {
-	newDevice := c.Deployment.Login(t, user.ClientType.HS, user.CSAPI, helpers.LoginOpts{
+	newDevice := c.Deployment.Login(t, string(user.ClientType.HS), user.CSAPI, helpers.LoginOpts{
 		DeviceID: newDeviceID,
 		Password: user.Password, // TODO: remove? not needed as inherited from client?
 	})

--- a/tests/delayed_requests_test.go
+++ b/tests/delayed_requests_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/matrix-org/gomatrixserverlib/spec"
 	"strings"
 	"testing"
 	"time"
@@ -70,7 +71,7 @@ func TestDelayedInviteResponse(t *testing.T) {
 				eventID := alice.MustSendMessage(t, roomID, "hello world!")
 
 				// bob joins, ensure he can decrypt the message.
-				tc.Bob.JoinRoom(t, roomID, []string{clientType.HS})
+				tc.Bob.JoinRoom(t, roomID, []spec.ServerName{clientType.HS})
 				bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasMembership(tc.Bob.UserID, "join")).Waitf(t, 7*time.Second, "did not see own join")
 				bob.MustBackpaginate(t, roomID, 3)
 

--- a/tests/device_keys_test.go
+++ b/tests/device_keys_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/matrix-org/gomatrixserverlib/spec"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -39,7 +40,7 @@ func TestFailedDeviceKeyDownloadRetries(t *testing.T) {
 		}, func() {
 			// And Alice and Bob are in an encrypted room together
 			roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}))
-			tc.Bob.MustJoinRoom(t, roomID, []string{"hs1"})
+			tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{"hs1"})
 
 			tc.WithAliceAndBobSyncing(t, func(alice, bob api.TestClient) {
 				// When Alice sends a message

--- a/tests/federation_connectivity_test.go
+++ b/tests/federation_connectivity_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"github.com/matrix-org/gomatrixserverlib/spec"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ func TestNewUserCannotGetKeysForOfflineServer(t *testing.T) {
 		})
 		roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}))
 		t.Logf("%s joining room %s", tc.Bob.UserID, roomID)
-		tc.Bob.MustJoinRoom(t, roomID, []string{"hs1"})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{"hs1"})
 
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.TestClient) {
 			// let clients sync device keys
@@ -51,7 +52,7 @@ func TestNewUserCannotGetKeysForOfflineServer(t *testing.T) {
 			tc.WithClientSyncing(t, &cc.ClientCreationRequest{
 				User: tc.Charlie,
 			}, func(charlie api.TestClient) {
-				tc.Charlie.MustJoinRoom(t, roomID, []string{"hs1"})
+				tc.Charlie.MustJoinRoom(t, roomID, []spec.ServerName{"hs1"})
 
 				// let charlie sync device keys... and fail to get bob's keys!
 				time.Sleep(time.Second)
@@ -118,8 +119,8 @@ func TestExistingSessionCannotGetKeysForOfflineServer(t *testing.T) {
 		roomIDbc := tc.CreateNewEncryptedRoom(t, tc.Charlie, cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}))
 		roomIDab := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}))
 		t.Logf("%s joining rooms %s and %s", tc.Bob.UserID, roomIDab, roomIDbc)
-		tc.Bob.MustJoinRoom(t, roomIDab, []string{"hs1"})
-		tc.Bob.MustJoinRoom(t, roomIDbc, []string{"hs1"})
+		tc.Bob.MustJoinRoom(t, roomIDab, []spec.ServerName{"hs1"})
+		tc.Bob.MustJoinRoom(t, roomIDbc, []spec.ServerName{"hs1"})
 
 		tc.WithAliceBobAndCharlieSyncing(t, func(alice, bob, charlie api.TestClient) {
 			// let clients sync device keys
@@ -141,7 +142,7 @@ func TestExistingSessionCannotGetKeysForOfflineServer(t *testing.T) {
 
 			// C now joins the room ab
 			tc.Alice.MustInviteRoom(t, roomIDab, tc.Charlie.UserID)
-			tc.Charlie.MustJoinRoom(t, roomIDab, []string{"hs1"})
+			tc.Charlie.MustJoinRoom(t, roomIDab, []spec.ServerName{"hs1"})
 
 			// let charlie sync device keys...
 			time.Sleep(time.Second)

--- a/tests/membership_acls_test.go
+++ b/tests/membership_acls_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"github.com/matrix-org/gomatrixserverlib/spec"
 	"testing"
 	"time"
 
@@ -30,7 +31,7 @@ func TestAliceBobEncryptionWorks(t *testing.T) {
 			cc.EncRoomOptions.PresetTrustedPrivateChat(),
 			cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}),
 		)
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 		// SDK testing below
 		// -----------------
@@ -87,7 +88,7 @@ func TestCanDecryptMessagesAfterInviteButBeforeJoin(t *testing.T) {
 			alice.MustSendMessage(t, roomID, wantMsgBody)
 
 			// Bob joins the room (via Complement, but it shouldn't matter)
-			tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+			tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 			isEncrypted, err = bob.IsRoomEncrypted(t, roomID)
 			must.NotError(t, "failed to check if room is encrypted", err)
@@ -131,7 +132,7 @@ func TestBobCanSeeButNotDecryptHistoryInPublicRoom(t *testing.T) {
 			waiter.Waitf(t, 5*time.Second, "alice did not see own message")
 
 			// now bob joins the room
-			tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+			tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 			time.Sleep(time.Second) // wait for it to appear on the client else rust crashes if it cannot find the room FIXME
 			waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasMembership(bob.UserID(), "join"))
 			waiter.Waitf(t, 5*time.Second, "bob did not see own join")
@@ -159,7 +160,7 @@ func TestOnRejoinBobCanSeeButNotDecryptHistoryInPublicRoom(t *testing.T) {
 		tc := Instance().CreateTestContext(t, clientTypeA, clientTypeB)
 		// shared history visibility
 		roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 		// SDK testing below
 		// -----------------
@@ -184,7 +185,7 @@ func TestOnRejoinBobCanSeeButNotDecryptHistoryInPublicRoom(t *testing.T) {
 			waiter.Waitf(t, 5*time.Second, "alice did not see own message")
 
 			// now bob rejoins the room, wait until he sees it.
-			tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+			tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 			waiter = bob.WaitUntilEventInRoom(t, roomID, api.CheckEventHasMembership(bob.UserID(), "join"))
 			waiter.Waitf(t, 5*time.Second, "bob did not see own join")
 			// this is required for some reason else tests fail
@@ -217,7 +218,7 @@ func TestOnNewDeviceBobCanSeeButNotDecryptHistoryInPublicRoom(t *testing.T) {
 		tc := Instance().CreateTestContext(t, clientTypeA, clientTypeB)
 		// shared history visibility
 		roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 		// SDK testing below
 		// -----------------
@@ -295,7 +296,7 @@ func TestChangingDeviceAfterInviteReEncrypts(t *testing.T) {
 				User: csapiBob2,
 			}, func(bob2 api.TestClient) {
 				time.Sleep(time.Second) // let device keys propagate
-				tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+				tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 				time.Sleep(time.Second) // let the client load the events
 				bob2.MustBackpaginate(t, roomID, 5)

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/matrix-org/gomatrixserverlib/spec"
 	"strings"
 	"testing"
 	"time"
@@ -49,7 +50,7 @@ func TestRoomKeyIsCycledOnDeviceLogout(t *testing.T) {
 			cc.EncRoomOptions.PresetTrustedPrivateChat(),
 			cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}),
 		)
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 		// Alice, Alice2 and Bob are in a room.
 		csapiAlice2 := tc.MustRegisterNewDevice(t, tc.Alice, "OTHER_DEVICE")
@@ -115,7 +116,7 @@ func TestRoomKeyIsCycledAfterEnoughMessages(t *testing.T) {
 			cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}),
 			cc.EncRoomOptions.RotationPeriodMsgs(5),
 		)
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.TestClient) {
 			// And some messages were sent, but not enough to trigger resending
@@ -189,7 +190,7 @@ func TestRoomKeyIsCycledAfterEnoughTime(t *testing.T) {
 			cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}),
 			cc.EncRoomOptions.RotationPeriodMs(int(rotationPeriod.Milliseconds())),
 		)
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.TestClient) {
 			// Before we start, ensure some keys have already been sent, so we
@@ -235,8 +236,8 @@ func TestRoomKeyIsCycledOnMemberLeaving(t *testing.T) {
 				cc.EncRoomOptions.PresetTrustedPrivateChat(),
 				cc.EncRoomOptions.Invite([]string{tc.Bob.UserID, tc.Charlie.UserID}),
 			)
-			tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
-			tc.Charlie.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+			tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
+			tc.Charlie.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 			alice.WaitUntilEventInRoom(t, roomID, api.CheckEventHasMembership(tc.Charlie.UserID, "join")).Waitf(t, 5*time.Second, "alice did not see charlie's join")
 			// check the room works
 			wantMsgBody := "Test Message"
@@ -278,7 +279,7 @@ func TestRoomKeyIsNotCycled(t *testing.T) {
 			cc.EncRoomOptions.PresetTrustedPrivateChat(),
 			cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}),
 		)
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 
 		// Alice, Bob are in a room.
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.TestClient) {
@@ -403,7 +404,7 @@ func testRoomKeyIsNotCycledOnClientRestartRust(t *testing.T, clientType api.Clie
 		cc.EncRoomOptions.PresetTrustedPrivateChat(),
 		cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}),
 	)
-	tc.Bob.MustJoinRoom(t, roomID, []string{clientType.HS})
+	tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientType.HS})
 
 	tc.WithClientSyncing(t, &cc.ClientCreationRequest{
 		User: tc.Bob,
@@ -467,7 +468,7 @@ func testRoomKeyIsNotCycledOnClientRestartJS(t *testing.T, clientType api.Client
 		cc.EncRoomOptions.PresetTrustedPrivateChat(),
 		cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}),
 	)
-	tc.Bob.MustJoinRoom(t, roomID, []string{clientType.HS})
+	tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientType.HS})
 
 	// Alice and Bob are in a room.
 	alice := tc.MustLoginClient(t, &cc.ClientCreationRequest{

--- a/tests/to_device_test.go
+++ b/tests/to_device_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"github.com/matrix-org/gomatrixserverlib/spec"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -21,7 +22,7 @@ func TestClientRetriesSendToDevice(t *testing.T) {
 	Instance().ClientTypeMatrix(t, func(t *testing.T, clientTypeA, clientTypeB api.ClientType) {
 		tc := Instance().CreateTestContext(t, clientTypeA, clientTypeB)
 		roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.PresetPublicChat())
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientTypeA.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientTypeA.HS})
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.TestClient) {
 			// lets device keys be exchanged
 			time.Sleep(time.Second)
@@ -76,7 +77,7 @@ func TestUnprocessedToDeviceMessagesArentLostOnRestart(t *testing.T) {
 		roomID := tc.CreateNewEncryptedRoom(t, tc.Alice,
 			cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}), cc.EncRoomOptions.RotationPeriodMsgs(1),
 		)
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientType.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientType.HS})
 		// the initial setup for rust/js is the same.
 		// login bob first so we have OTKs
 		bob := tc.MustLoginClient(t, &cc.ClientCreationRequest{
@@ -274,7 +275,7 @@ func TestToDeviceMessagesAreBatched(t *testing.T) {
 		// create 100 users
 		for i := 0; i < 100; i++ {
 			user := tc.RegisterNewUser(t, clientType, "bob")
-			user.MustJoinRoom(t, roomID, []string{clientType.HS})
+			user.MustJoinRoom(t, roomID, []spec.ServerName{clientType.HS})
 			// this blocks until it has uploaded OTKs/device keys
 			clientUnderTest := tc.MustLoginClient(t, &cc.ClientCreationRequest{
 				User: user,
@@ -344,7 +345,7 @@ func TestToDeviceMessagesArentLostWhenKeysQueryFails(t *testing.T) {
 		tc := Instance().CreateTestContext(t, clientType, clientType)
 		// get a normal E2EE room set up
 		roomID := tc.CreateNewEncryptedRoom(t, tc.Alice, cc.EncRoomOptions.Invite([]string{tc.Bob.UserID}))
-		tc.Bob.MustJoinRoom(t, roomID, []string{clientType.HS})
+		tc.Bob.MustJoinRoom(t, roomID, []spec.ServerName{clientType.HS})
 		tc.WithAliceAndBobSyncing(t, func(alice, bob api.TestClient) {
 			msg := "hello world"
 			msg2 := "new device message from alice"
@@ -466,7 +467,7 @@ func TestToDeviceMessagesAreProcessedInOrder(t *testing.T) {
 					creationReqs[i] = &cc.ClientCreationRequest{
 						User: tc.RegisterNewUser(t, clientType, "ilikebots"),
 					}
-					creationReqs[i].User.MustJoinRoom(t, roomID, []string{clientType.HS})
+					creationReqs[i].User.MustJoinRoom(t, roomID, []spec.ServerName{clientType.HS})
 				}
 				// send 30 messages as each user (interleaved)
 				tc.WithClientsSyncing(t, creationReqs, func(clients []api.TestClient) {


### PR DESCRIPTION
A few changes have landed in Complement, so we need to update.

The breaking changes in the API are:
 * `MustJoinRoom` now takes an array of `ServerName`s rather than an array of
   `string`s. To make it easier to build such an array, I've also changed the type
   of `ClientType.HS` to ServerName.

 * `WithCleanup` now takes a function which receives a parameter.