### PR TITLE
Build JS-SDK before trying to use it in CI

### DIFF
--- a/.github/workflows/install-js-sdk.sh
+++ b/.github/workflows/install-js-sdk.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Helper for the single_sdk_tests workflow: builds and installs the js-sdk from a given source.
+# The aim is to provide the right location of the JS SDK to rebuild_js_sdk.sh.
+#
+# Usage: `install-js-sdk.sh <source>` where `<source>` is one of:
+#
+#  * `.`  to use the current directory, or
+#  * The name of a branch within ``matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk`
+
+set -ex
+
+js_sdk_src="$1"
+
+if [ -z "$js_sdk_src" ]; then
+    echo "Usage: $0 <jssdk source>" >&2
+    exit 1
+fi
+
+complement_crypto_dir="$(dirname $0)/../../"
+
+echo "Installing matrix-js-sdk @ $js_sdk_src"
+
+if [ "$js_sdk_src" = "." ]; then
+    # If we install from a local directory, we have to build the js-sdk ourselves.
+    echo "Building js-sdk @ $(pwd)"
+    yarn install
+
+    yarn_path="file:$(pwd)"
+else
+    # No need to build the js-sdk when installing from git: yarn will do it for us.
+    yarn_path="https://github.com/matrix-org/matrix-js-sdk#$js_sdk_src"
+fi
+
+cd "$complement_crypto_dir"
+./rebuild_js_sdk.sh "matrix-js-sdk@$yarn_path"

--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -113,7 +113,6 @@ jobs:
             go install -v github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
 
         # JS SDK only steps
-        # The aim is to provide the right location of the JS SDK to rebuild_js_sdk.sh
         - name: Setup | Node.js LTS
           if: ${{ inputs.use_js_sdk != '' }}
           uses: actions/setup-node@v3
@@ -122,13 +121,7 @@ jobs:
         - name: "Install JS SDK"
           if: ${{ inputs.use_js_sdk != '' }}
           shell: bash
-          run: |
-            echo "Installing matrix-js-sdk @ $JS_SDK"
-            YARN_PATH="https://github.com/matrix-org/matrix-js-sdk#$JS_SDK"
-            if [ "$JS_SDK" = "." ]; then
-              YARN_PATH="file:${{ github.workspace }}"
-            fi
-            (cd complement-crypto && ./rebuild_js_sdk.sh "matrix-js-sdk@$YARN_PATH")
+          run: ./complement-crypto/.github/workflows/install-js-sdk.sh "$JS_SDK"
 
         # Rust SDK only steps.
         # The aim is to guarantee that rust-sdk is either at '.' or './complement-crypto/rust-sdk'


### PR DESCRIPTION
Followup to https://github.com/matrix-org/complement-crypto/pull/194: now that we use the built JS rather than the TS source, we need to actually build the js-sdk.

Otherwise, when the JS-SDK's CI runs, we get errors from `vite`.