### PR TITLE
Bump to uniffi 0.28.3

### DIFF
--- a/install_uniffi_bindgen_go.sh
+++ b/install_uniffi_bindgen_go.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 set -o pipefail
 
-cargo install uniffi-bindgen-go --tag v0.2.2+v0.25.0 --git https://github.com/NordSecurity/uniffi-bindgen-go
+cargo install uniffi-bindgen-go --tag v0.4.0+v0.28.3 --git https://github.com/NordSecurity/uniffi-bindgen-go

--- a/install_uniffi_bindgen_go.sh
+++ b/install_uniffi_bindgen_go.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 set -o pipefail
 
-cargo install uniffi-bindgen-go --tag v0.4.0+v0.28.3 --git https://github.com/NordSecurity/uniffi-bindgen-go
+cargo install uniffi-bindgen-go --tag v0.4.0+v0.28.3 --git https://github.com/kegsay/uniffi-bindgen-go

--- a/internal/api/rust/session_delegate.go
+++ b/internal/api/rust/session_delegate.go
@@ -12,7 +12,7 @@ func NewMemoryClientSessionDelegate() *MemoryClientSessionDelegate {
 	}
 }
 
-func (d *MemoryClientSessionDelegate) RetrieveSessionFromKeychain(userID string) (matrix_sdk_ffi.Session, *matrix_sdk_ffi.ClientError) {
+func (d *MemoryClientSessionDelegate) RetrieveSessionFromKeychain(userID string) (matrix_sdk_ffi.Session, error) {
 	s, exists := d.userIDToSession[userID]
 	if !exists {
 		return matrix_sdk_ffi.Session{}, matrix_sdk_ffi.NewClientErrorGeneric("Failed to find RestorationToken in the Keychain.", nil)

--- a/rebuild_rust_sdk.sh
+++ b/rebuild_rust_sdk.sh
@@ -45,8 +45,8 @@ cd $RUST_SDK_DIR;
 cp Cargo.toml Cargo.toml.backup
 cp Cargo.lock Cargo.lock.backup
 trap "mv $RUST_SDK_DIR/Cargo.toml.backup $RUST_SDK_DIR/Cargo.toml; mv $RUST_SDK_DIR/Cargo.lock.backup $RUST_SDK_DIR/Cargo.lock" EXIT INT TERM
-sed -i.bak 's/uniffi =.*/uniffi = "0\.25\.3"/' Cargo.toml
-sed -i.bak 's^uniffi_bindgen =.*^uniffi_bindgen = { git = "https:\/\/github.com\/mozilla\/uniffi-rs", rev = "0a03b713306d6ce3de033157fc2ce92a238c2e24" }^' Cargo.toml
+sed -i.bak 's/uniffi =.*/uniffi = "0\.28\.3"/' Cargo.toml
+sed -i.bak 's^uniffi_bindgen =.*^uniffi_bindgen = { git = "https:\/\/github.com\/mozilla\/uniffi-rs", rev = "f7a0ba703b4c06fff8fffa98078f2e5d7588a695" }^' Cargo.toml
 sed -i.bak 's#matrix-sdk-crypto = {#matrix-sdk-crypto = {features = ["_disable-minimum-rotation-period-ms"],#' Cargo.toml
 cargo build -p matrix-sdk-ffi --features 'native-tls,sentry'
 # generate the bindings


### PR DESCRIPTION
Doesn't quite address https://github.com/matrix-org/complement-crypto/issues/197 yet as that needs another bump to 0.29.x but this does go much further.

Upstream PRs:
 - https://github.com/NordSecurity/uniffi-bindgen-go/pull/81
 - https://github.com/NordSecurity/uniffi-bindgen-go/pull/82