### PR TITLE
Remove reference to `matrix-sdk/rustls-tls` feature flag

### DIFF
--- a/rebuild_rust_sdk.sh
+++ b/rebuild_rust_sdk.sh
@@ -54,7 +54,7 @@ trap "restore_backups" EXIT INT TERM
 sed -i.bak 's/"wasm-unstable-single-threaded"//' bindings/matrix-sdk-ffi/Cargo.toml
 # Enable a hidden feature to make tests run faster.
 sed -i.bak 's#matrix-sdk-crypto = {#matrix-sdk-crypto = {features = ["_disable-minimum-rotation-period-ms"],#' Cargo.toml
-cargo build -p matrix-sdk-ffi --features 'rustls-tls,sentry'
+cargo build -p matrix-sdk-ffi --features 'sentry'
 # generate the bindings
 echo "generating bindings to $COMPLEMENT_DIR/internal/api/rust...";
 uniffi-bindgen-go -o $COMPLEMENT_DIR/internal/api/rust --config $COMPLEMENT_DIR/uniffi.toml --library ./target/debug/libmatrix_sdk_ffi.a


### PR DESCRIPTION
**Note:** _this pull request should be merged in conjunction with matrix-org/matrix-rust-sdk#6409_.

This pull request removes reference to the `matrix-sdk/rustls-tls` flag when building the `matrix-sdk` in `rebuild_rust_sdk.sh`. Note that this is necessary because the flag is being deprecated in matrix-org/matrix-rust-sdk#6409, and consequently, `rustls` will become the only supported TLS backend. 

In other words, referencing the flag will break the build, and removing the reference will maintain the same behavior as before.