### PR TITLE
Revert "Upgrade Chromium in the CI flows to avoid flaking

### DIFF
--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -37,10 +37,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup | Chromium
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get -qq -y install chromium-browser
       - name: Resolve branches
         shell: bash
         # these env vars will be modified and used in subsequent steps

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,10 +50,6 @@ jobs:
         run: |
           rustup toolchain install stable
           rustup default stable
-      - name: Setup | Chromium
-        run: |
-          sudo apt-get -qq update
-          sudo apt-get -qq -y install chromium-browser
       - name: Checkout matrix-rust-sdk
         run: |
           BRANCH=$(./.github/workflows/resolve_branch.sh matrix-org/matrix-rust-sdk)


### PR DESCRIPTION
Reverts matrix-org/complement-crypto#235. 

This should no longer be required, because the Github runner images now come with Chromium 148, which shouldn't exhibit the bug we were trying to avoid.

Further, the "Setup | Chromium" step is currently failing, because the Ubuntu snap store is down.