### PR TITLE
Update package manager detection in install script

### DIFF
--- a/.github/workflows/install-js-sdk.sh
+++ b/.github/workflows/install-js-sdk.sh
@@ -26,9 +26,9 @@ if [ "$js_sdk_src" = "." ]; then
     # If we install from a local directory, we have to build the js-sdk ourselves.
     echo "Building js-sdk @ $(pwd)"
 
-    PM=$(cat package.json | jq -r '.packageManager')
+    PM=$(cat package.json | jq -r '.devEngines.packageManager.name // .packageManager')
     case "$PM" in
-        "pnpm@"*) pnpm install ;;
+        "pnpm"|"pnpm@"*) pnpm install ;;
         *) yarn install ;;
     esac
 


### PR DESCRIPTION
To handle `devEngines.packageManager` specification, as root `packageManager` is deprecated

Blocking https://github.com/matrix-org/matrix-js-sdk/pull/5338