### PR TITLE
Switch to gotestsum to rerun flaky tests

### DIFF
--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -111,6 +111,8 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: "1.25"
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
       - name: "Install Complement Dependencies"
         shell: bash
         run: |
@@ -170,7 +172,7 @@ jobs:
           export COMPLEMENT_CRYPTO_RPC_BINARY="$(pwd)/complement-crypto/rpc"
           cd complement-crypto &&
           set -o pipefail &&
-          go test -v -p 2 -count=1 -json -tags=$GO_TAGS -timeout 15m ./tests ./tests/$LANG_SPECIFIC_TESTS | gotestfmt
+          gotestsum --format=testname --rerun-fails=5 --packages="./tests ./tests/$LANG_SPECIFIC_TESTS" -- -v -p 2 -count=1 -json -tags=$GO_TAGS -timeout 15m
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         env:
           COMPLEMENT_BASE_IMAGE: homeserver

--- a/.github/workflows/single_sdk_tests.yml
+++ b/.github/workflows/single_sdk_tests.yml
@@ -137,6 +137,11 @@ jobs:
         run: |
           rustup toolchain install stable
           rustup default stable
+      - name: Install just
+        if: ${{ inputs.use_rust_sdk != '' }}
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419
+        with:
+          tool: just
       - name: "Download Rust SDK" # no need to download rust SDK if we are using the local checkout.
         if: ${{ inputs.use_rust_sdk != '' && inputs.use_rust_sdk != '.'}}
         run: |
@@ -149,7 +154,7 @@ jobs:
           RUST_SDK_DIR: ${{ inputs.use_rust_sdk == '.' && '..' || './rust-sdk' }}
         run: |
           echo "Compiling matrix-rust-sdk @ $RUST_SDK"
-          cd complement-crypto && ./install_uniffi_bindgen_go.sh && ./rebuild_rust_sdk.sh $RUST_SDK_DIR
+          cd complement-crypto && just install-uniffi-bindgen && ./rebuild_rust_sdk.sh $RUST_SDK_DIR
 
       - name: Build RPC client (rust)
         if: ${{ inputs.use_rust_sdk != '' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -46,6 +46,10 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: "1.25"
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Setup | Rust
         run: |
           rustup toolchain install stable
@@ -156,7 +160,7 @@ jobs:
           export LD_LIBRARY_PATH="$(pwd)/rust-sdk/target/debug"
           export COMPLEMENT_CRYPTO_RPC_BINARY="$(pwd)/rpc"
           set -o pipefail &&
-          go test -p 3 -v -json -tags='jssdk,rust' -count=1 -timeout 15m ./tests ./tests/js ./tests/rust | gotestfmt
+          gotestsum --format=testname --rerun-fails=5 --packages="./tests ./tests/js ./tests/rust" -- -v -p 3 -count=1 -json -tags='jssdk,rust' -timeout 15m
         shell: bash # required for pipefail to be A Thing. pipefail is required to stop gotestfmt swallowing non-zero exit codes
         name: Run Complement Crypto Tests
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,10 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           workspaces: "rust-sdk"
+      - name: Install just
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419
+        with:
+          tool: just
       - name: "Install Complement Dependencies"
         run: |
           go install -v github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@4c97682ab858d6bbd26fc020e255cb339c9c8119 # v2.5.0
@@ -72,7 +76,7 @@ jobs:
 
       - name: Build Rust FFI bindings
         run: |
-          ./install_uniffi_bindgen_go.sh && ./rebuild_rust_sdk.sh ./rust-sdk
+          just install-uniffi-bindgen && ./rebuild_rust_sdk.sh ./rust-sdk
 
       # Temporary: as it takes 3m to build the complement synapse image >:(
       # If you're bumping the image version here, don't forget to bump it in ./single_sdk_tests.yml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ js-sdk/dist
 /internal/api/js/js-sdk/dist/
 /internal/api/js/js-sdk/node_modules/
 /internal/api/rust/matrix_sdk*
+/internal/api/rust/ruma*
 /internal/tests/logs/
 __pycache__
 /rust-sdk/

--- a/install_uniffi_bindgen_go.sh
+++ b/install_uniffi_bindgen_go.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -e
-set -o pipefail
-
-cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.7.0+v0.31.0

--- a/justfile
+++ b/justfile
@@ -1,9 +1,9 @@
 # Build and run complement-crypto tests
 
-set dotenv-load := true
+set dotenv-load
 
 BASE_IMAGE := "ghcr.io/matrix-org/synapse-service:v1.117.0"
-UNIFFI_GO_VERSION := "v0.4.0+v0.28.3"
+UNIFFI_GO_VERSION := "v0.7.1+v0.31.0"
 
 # List the available recipes.
 default:
@@ -25,4 +25,4 @@ build-rust-bindings rust-sdk-path:
 
 # Install the uniffi-bindgen-go command line utility, necessary to build the bindings.
 install-uniffi-bindgen:
-    cargo install uniffi-bindgen-go --tag {{ UNIFFI_GO_VERSION }} --git https://github.com/kegsay/uniffi-bindgen-go
+    cargo install uniffi-bindgen-go --tag {{ UNIFFI_GO_VERSION }} --git https://github.com/NordSecurity/uniffi-bindgen-go

--- a/rebuild_rust_sdk.sh
+++ b/rebuild_rust_sdk.sh
@@ -40,7 +40,7 @@ else # HTTPS URL => git clone into temp dir
 fi
 
 function restore_backups {
-    for i in Cargo.toml Cargo.lock bindings/matrix-sdk-ffi/Cargo.toml; do
+    for i in Cargo.toml Cargo.lock; do
         mv "$RUST_SDK_DIR/$i.backup" "$RUST_SDK_DIR/$i"
     done
 }
@@ -49,9 +49,7 @@ echo 'building matrix-sdk-ffi...';
 cd $RUST_SDK_DIR;
 cp Cargo.toml Cargo.toml.backup
 cp Cargo.lock Cargo.lock.backup
-cp bindings/matrix-sdk-ffi/Cargo.toml bindings/matrix-sdk-ffi/Cargo.toml.backup
 trap "restore_backups" EXIT INT TERM
-sed -i.bak 's/"wasm-unstable-single-threaded"//' bindings/matrix-sdk-ffi/Cargo.toml
 # Enable a hidden feature to make tests run faster.
 sed -i.bak 's#matrix-sdk-crypto = {#matrix-sdk-crypto = {features = ["_disable-minimum-rotation-period-ms"],#' Cargo.toml
 cargo build -p matrix-sdk-ffi --features 'sentry'

--- a/tests/membership_acls_test.go
+++ b/tests/membership_acls_test.go
@@ -198,6 +198,8 @@ func TestOnRejoinBobCanSeeButNotDecryptHistoryInPublicRoom(t *testing.T) {
 			must.NotEqual(t, ev.Text, onlyAliceBody, "bob was able to decrypt a message from before he was joined")
 			must.Equal(t, ev.FailedToDecrypt, true, "message not marked as failed to decrypt")
 
+			t.Logf("Bob has received the event but couldn't decrypt it, everything is ok")
+
 			/* TODO: needs client changes
 			time.Sleep(time.Second) // let alice realise bob is back in the room
 			// bob should be able to decrypt subsequent messages


### PR DESCRIPTION
Might close: https://github.com/matrix-org/complement-crypto/issues/245

Relevant commit for #245 is https://github.com/matrix-org/complement-crypto/pull/254/changes/f780657967d1ec4dc6407523da622b120927a22e, which bumped uniffi-bindgen-go.

The bump includes the following fix https://github.com/NordSecurity/uniffi-bindgen-go/pull/91.