### PR TITLE
Bump the uniffi-bindgen-go version

### DIFF
--- a/install_uniffi_bindgen_go.sh
+++ b/install_uniffi_bindgen_go.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 set -o pipefail
 
-cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.7.0+v0.31.0
+cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.7.1+v0.31.0

--- a/justfile
+++ b/justfile
@@ -1,9 +1,9 @@
 # Build and run complement-crypto tests
 
-set dotenv-load := true
+set dotenv-load
 
 BASE_IMAGE := "ghcr.io/matrix-org/synapse-service:v1.117.0"
-UNIFFI_GO_VERSION := "v0.4.0+v0.28.3"
+UNIFFI_GO_VERSION := "v0.7.1+v0.31.0"
 
 # List the available recipes.
 default:
@@ -25,4 +25,4 @@ build-rust-bindings rust-sdk-path:
 
 # Install the uniffi-bindgen-go command line utility, necessary to build the bindings.
 install-uniffi-bindgen:
-    cargo install uniffi-bindgen-go --tag {{ UNIFFI_GO_VERSION }} --git https://github.com/kegsay/uniffi-bindgen-go
+    cargo install uniffi-bindgen-go --tag {{ UNIFFI_GO_VERSION }} --git https://github.com/NordSecurity/uniffi-bindgen-go/


### PR DESCRIPTION
This PR bumps uniffi-bindgen-go to include the following fix: https://github.com/NordSecurity/uniffi-bindgen-go/commit/f51041323447cefa651ab20180a5f7725298e140.

This fixes errors on the Rust side raising panics on the Go side, like we saw in #245.