### PR TITLE
Simplify Rust SDK build

### DIFF
--- a/rebuild_rust_sdk.sh
+++ b/rebuild_rust_sdk.sh
@@ -39,20 +39,9 @@ else # HTTPS URL => git clone into temp dir
   git clone --depth 1 --branch ${SEGMENTS[1]} ${SEGMENTS[0]} $RUST_SDK_DIR;
 fi
 
-function restore_backups {
-    for i in Cargo.toml Cargo.lock; do
-        mv "$RUST_SDK_DIR/$i.backup" "$RUST_SDK_DIR/$i"
-    done
-}
-
 echo 'building matrix-sdk-ffi...';
 cd $RUST_SDK_DIR;
-cp Cargo.toml Cargo.toml.backup
-cp Cargo.lock Cargo.lock.backup
-trap "restore_backups" EXIT INT TERM
-# Enable a hidden feature to make tests run faster.
-sed -i.bak 's#matrix-sdk-crypto = {#matrix-sdk-crypto = {features = ["_disable-minimum-rotation-period-ms"],#' Cargo.toml
-cargo build -p matrix-sdk-ffi --features 'sentry'
+cargo build -p matrix-sdk-ffi --features 'sentry, _only-for-testing-disable-megolm-minimum-rotation-period-ms'
 # generate the bindings
 echo "generating bindings to $COMPLEMENT_DIR/internal/api/rust...";
 uniffi-bindgen-go -o $COMPLEMENT_DIR/internal/api/rust --config $COMPLEMENT_DIR/uniffi.toml --library ./target/debug/libmatrix_sdk_ffi.a

--- a/rebuild_rust_sdk.sh
+++ b/rebuild_rust_sdk.sh
@@ -40,7 +40,7 @@ else # HTTPS URL => git clone into temp dir
 fi
 
 function restore_backups {
-    for i in Cargo.toml Cargo.lock bindings/matrix-sdk-ffi/Cargo.toml; do
+    for i in Cargo.toml Cargo.lock; do
         mv "$RUST_SDK_DIR/$i.backup" "$RUST_SDK_DIR/$i"
     done
 }
@@ -49,9 +49,7 @@ echo 'building matrix-sdk-ffi...';
 cd $RUST_SDK_DIR;
 cp Cargo.toml Cargo.toml.backup
 cp Cargo.lock Cargo.lock.backup
-cp bindings/matrix-sdk-ffi/Cargo.toml bindings/matrix-sdk-ffi/Cargo.toml.backup
 trap "restore_backups" EXIT INT TERM
-sed -i.bak 's/"wasm-unstable-single-threaded"//' bindings/matrix-sdk-ffi/Cargo.toml
 # Enable a hidden feature to make tests run faster.
 sed -i.bak 's#matrix-sdk-crypto = {#matrix-sdk-crypto = {features = ["_disable-minimum-rotation-period-ms"],#' Cargo.toml
 cargo build -p matrix-sdk-ffi --features 'sentry'


### PR DESCRIPTION
We were manually rewriting `Cargo.toml` files of the Rust SDK to enable building with differing uniffi versions and to enable certain hidden features.

This is possible because:
1. We're on the same uniffi version as the Rust SDK, meaning the uniffi versions have the same feature sets
2. [We re-exposed a feature flag](https://github.com/matrix-org/matrix-rust-sdk/pull/6827) of the `matrix-sdk-crypto` crate in the `matrix-sdk-ffi` crate which complement-crypto can now enable