### PR TITLE
Add Ruma to the git ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ js-sdk/dist
 /internal/api/js/js-sdk/dist/
 /internal/api/js/js-sdk/node_modules/
 /internal/api/rust/matrix_sdk*
+/internal/api/rust/ruma*
 /internal/tests/logs/
 __pycache__
 /rust-sdk/


### PR DESCRIPTION
Since now Ruma directly re-exports some types, we have some new internal APIs.