### PR TITLE
Schedule the main tests workflow to run daily

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,8 @@ on:
     branches: ["main"]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   check-signoff:


### PR DESCRIPTION
This allows us to gather analytics and stats about our tests, mainly to get visibility on which tests are the flakiest ones.