### PR TITLE
Use `ct` wrappers for `T.Errorf` and `T.Fatalf`

### DIFF
--- a/internal/api/rust/dynamic_slice_test.go
+++ b/internal/api/rust/dynamic_slice_test.go
@@ -3,6 +3,8 @@ package rust
 import (
 	"slices"
 	"testing"
+
+	"github.com/matrix-org/complement/ct"
 )
 
 func mustEqual(t *testing.T, got, want []int, msg string) {

--- a/internal/api/rust/dynamic_slice_test.go
+++ b/internal/api/rust/dynamic_slice_test.go
@@ -10,7 +10,7 @@ import (
 func mustEqual(t *testing.T, got, want []int, msg string) {
 	t.Helper()
 	if !slices.Equal(got, want) {
-		t.Errorf("%s, got %v want %v", msg, got, want)
+		ct.Errorf(t, "%s, got %v want %v", msg, got, want)
 	}
 }
 

--- a/internal/api/rust/generic_state_listener_test.go
+++ b/internal/api/rust/generic_state_listener_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/must"
 )
 
@@ -13,7 +14,7 @@ func receiveFromChannel(t *testing.T, ch <-chan string) string {
 	case val := <-ch:
 		return val
 	case <-time.After(time.Second):
-		t.Fatalf("failed to receive from channel")
+		ct.Fatalf(t, "failed to receive from channel")
 	}
 	return ""
 }

--- a/internal/api/rust/room_listener_test.go
+++ b/internal/api/rust/room_listener_test.go
@@ -3,6 +3,7 @@ package rust
 import (
 	"testing"
 
+	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/complement/must"
 )
 
@@ -40,7 +41,7 @@ func TestRoomListener(t *testing.T) {
 	rl.BroadcastUpdateForRoom("quuz")
 	select {
 	case <-recv:
-		t.Fatalf("received room id after cancel()")
+		ct.Fatalf(t, "received room id after cancel()")
 	default:
 		// we expect to hit this
 	}
@@ -54,7 +55,7 @@ func TestRoomListener(t *testing.T) {
 	rl.BroadcastUpdateForRoom("no one is listening")
 	select {
 	case <-recv2:
-		t.Fatalf("received room id after returning true")
+		ct.Fatalf(t, "received room id after returning true")
 	default:
 		// we expect to hit this
 	}

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -317,7 +317,7 @@ func (c *RustClient) DeletePersistentStorage(t ct.TestLike) {
 }
 func (c *RustClient) ForceClose(t ct.TestLike) {
 	t.Helper()
-	t.Fatalf("Cannot force close a rust client, use an RPC client instead.")
+	ct.Fatalf(t, "Cannot force close a rust client, use an RPC client instead.")
 }
 
 func (c *RustClient) Close(t ct.TestLike) {

--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -261,7 +261,7 @@ func (c *RustClient) RequestOwnUserVerification(t ct.TestLike) chan api.Verifica
 		},
 		SendCancel: func() {
 			if err := svc.CancelVerification(); err != nil {
-				t.Errorf("failed to CancelVerification: %s", err)
+				ct.Errorf(t, "failed to CancelVerification: %s", err)
 			}
 		},
 		SendStart: func(method string) {
@@ -270,17 +270,17 @@ func (c *RustClient) RequestOwnUserVerification(t ct.TestLike) chan api.Verifica
 				return
 			}
 			if err := svc.StartSasVerification(); err != nil {
-				t.Errorf("failed to StartSasVerification: %s", err)
+				ct.Errorf(t, "failed to StartSasVerification: %s", err)
 			}
 		},
 		SendApprove: func() {
 			if err := svc.ApproveVerification(); err != nil {
-				t.Errorf("failed to ApproveVerification: %s", err)
+				ct.Errorf(t, "failed to ApproveVerification: %s", err)
 			}
 		},
 		SendDecline: func() {
 			if err := svc.DeclineVerification(); err != nil {
-				t.Errorf("failed to ApproveVerification: %s", err)
+				ct.Errorf(t, "failed to ApproveVerification: %s", err)
 			}
 		},
 		SendTransition: func() {

--- a/internal/cc/instance.go
+++ b/internal/cc/instance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/complement-crypto/internal/api"
 	"github.com/matrix-org/complement-crypto/internal/config"
 	"github.com/matrix-org/complement-crypto/internal/deploy"
+	"github.com/matrix-org/complement/ct"
 
 	complementconfig "github.com/matrix-org/complement/config"
 )
@@ -124,7 +125,7 @@ func (i *Instance) CreateTestContext(t *testing.T, clientType ...api.ClientType)
 		tc.Charlie = tc.RegisterNewUser(t, clientType[2], "charlie")
 	}
 	if len(clientType) > 3 {
-		t.Fatalf("CreateTestContext: too many clients: got %d", len(clientType))
+		ct.Fatalf(t, "CreateTestContext: too many clients: got %d", len(clientType))
 	}
 	return tc
 }

--- a/internal/cc/test_context.go
+++ b/internal/cc/test_context.go
@@ -116,7 +116,7 @@ func (c *TestContext) mustCreateMultiprocessClient(t *testing.T, req *ClientCrea
 	ctxPrefix := fmt.Sprintf("%d", c.RPCInstance.Add(1))
 	remoteBindings, err := rpc.NewLanguageBindings(c.RPCBinaryPath, req.User.ClientType.Lang, ctxPrefix)
 	if err != nil {
-		t.Fatalf("Failed to create new RPC language bindings: %s", err)
+		ct.Fatalf(t, "Failed to create new RPC language bindings: %s", err)
 	}
 	return api.NewTestClient(remoteBindings.MustCreateClient(t, req.Opts))
 }
@@ -319,7 +319,7 @@ func (c *TestContext) MustCreateClient(t *testing.T, req *ClientCreationRequest)
 func mustCreateClient(t *testing.T, clientType api.ClientType, cfg api.ClientCreationOpts) api.TestClient {
 	bindings := langs.GetLanguageBindings(clientType.Lang)
 	if bindings == nil {
-		t.Fatalf("unknown language: %s", clientType.Lang)
+		ct.Fatalf(t, "unknown language: %s", clientType.Lang)
 	}
 	c := bindings.MustCreateClient(t, cfg)
 	return api.NewTestClient(c)

--- a/internal/deploy/rpc/client.go
+++ b/internal/deploy/rpc/client.go
@@ -165,7 +165,7 @@ func (c *RPCClient) ForceClose(t ct.TestLike) {
 	t.Helper()
 	err := c.rpcCmd.Process.Kill()
 	if err != nil {
-		t.Fatalf("failed to kill process: %s", err)
+		ct.Fatalf(t, "failed to kill process: %s", err)
 	}
 }
 
@@ -230,7 +230,7 @@ func (c *RPCClient) DeletePersistentStorage(t ct.TestLike) {
 	var void int
 	err := c.client.Call("Server.DeletePersistentStorage", t.Name(), &void)
 	if err != nil {
-		t.Fatalf("RPCClient.DeletePersistentStorage: %s", err)
+		ct.Fatalf(t, "RPCClient.DeletePersistentStorage: %s", err)
 	}
 }
 func (c *RPCClient) Login(t ct.TestLike, opts api.ClientCreationOpts) error {
@@ -295,7 +295,7 @@ func (c *RPCClient) WaitUntilEventInRoom(t ct.TestLike, roomID string, checker f
 		RoomID:   roomID,
 	}, &waiterID)
 	if err != nil {
-		t.Fatalf("RPCClient.WaitUntilEventInRoom: %s", err)
+		ct.Fatalf(t, "RPCClient.WaitUntilEventInRoom: %s", err)
 	}
 	return &RPCWaiter{
 		client:   c.client,
@@ -356,7 +356,7 @@ func (c *RPCClient) Logf(t ct.TestLike, format string, args ...interface{}) {
 	var void int
 	err := c.client.Call("Server.Logf", str, &void)
 	if err != nil {
-		t.Fatalf("RPCClient.Logf: %s", err)
+		ct.Fatalf(t, "RPCClient.Logf: %s", err)
 	}
 }
 

--- a/internal/tests/client_test.go
+++ b/internal/tests/client_test.go
@@ -41,7 +41,7 @@ func Deploy(t *testing.T) *deploy.ComplementCryptoDeployment {
 	}
 	wd, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("failed to get wd: %s", err)
+		ct.Fatalf(t, "failed to get wd: %s", err)
 	}
 	ssDeployment = deploy.RunNewDeployment(t, filepath.Join(wd, "../../tests/mitmproxy_addons"), "")
 	return ssDeployment
@@ -51,14 +51,14 @@ func TestMain(m *testing.M) {
 	rustClientCreator := func(t *testing.T, cfg api.ClientCreationOpts) api.TestClient {
 		client, err := rust.NewRustClient(t, cfg)
 		if err != nil {
-			t.Fatalf("NewRustClient: %s", err)
+			ct.Fatalf(t, "NewRustClient: %s", err)
 		}
 		return api.NewTestClient(client)
 	}
 	jsClientCreator := func(t *testing.T, cfg api.ClientCreationOpts) api.TestClient {
 		client, err := js.NewJSClient(t, cfg)
 		if err != nil {
-			t.Fatalf("NewJSClient: %s", err)
+			ct.Fatalf(t, "NewJSClient: %s", err)
 		}
 		return api.NewTestClient(client)
 	}

--- a/internal/tests/client_test.go
+++ b/internal/tests/client_test.go
@@ -5,7 +5,10 @@ package tests
 
 import (
 	"fmt"
+
 	complementconfig "github.com/matrix-org/complement/config"
+	"github.com/matrix-org/complement/ct"
+
 	"log"
 	"os"
 	"path/filepath"

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -398,7 +398,7 @@ func TestRoomKeyIsNotCycledOnClientRestart(t *testing.T) {
 		case api.ClientTypeJS:
 			testRoomKeyIsNotCycledOnClientRestartJS(t, a)
 		default:
-			t.Fatalf("unknown lang: %s", a.Lang)
+			ct.Fatalf(t, "unknown lang: %s", a.Lang)
 		}
 	})
 }
@@ -613,7 +613,7 @@ func withSpoofSender(t *testing.T, tc *cc.TestContext, attackerUserID string, ta
 				t.Logf("Rewriting event %s from %s to have sender of %s", event.Get("event_id").String(), event.Get("sender").String(), spoofedUserID)
 				var err error
 				if eventArrayRaw, err = sjson.Set(eventArrayRaw, fmt.Sprintf("%d.sender", idx.Int()), spoofedUserID); err != nil {
-					t.Fatalf("Couldn't patch event array: %s", err)
+					ct.Fatalf(t, "Couldn't patch event array: %s", err)
 				}
 			}
 			return true
@@ -636,7 +636,7 @@ func withSpoofSender(t *testing.T, tc *cc.TestContext, attackerUserID string, ta
 				roomListJSONPath = "rooms"
 				timelineJSONPath = "timeline"
 			} else {
-				t.Fatalf("Unknown sync endpoint: %s", cd.URL)
+				ct.Fatalf(t, "Unknown sync endpoint: %s", cd.URL)
 			}
 
 			rawBody := string(cd.ResponseBody)
@@ -648,7 +648,7 @@ func withSpoofSender(t *testing.T, tc *cc.TestContext, attackerUserID string, ta
 				jsonPath := fmt.Sprintf("%s.%s.%s", roomListJSONPath, gjson.Escape(roomID.String()), timelineJSONPath)
 				var err error
 				if rawBody, err = sjson.SetRaw(rawBody, jsonPath, patchedTimeline); err != nil {
-					t.Fatalf("Couldn't patch response json: %s", err)
+					ct.Fatalf(t, "Couldn't patch response json: %s", err)
 				}
 				return true
 			})

--- a/tests/room_keys_test.go
+++ b/tests/room_keys_test.go
@@ -572,7 +572,7 @@ func TestSpoofedEventSenderHandling(t *testing.T) {
 					shield, err := bob.GetEventShield(t, roomID, spoofedEventID)
 					must.NotError(t, "Could not get shield for Bob's view of spoofed message", err)
 					if shield == nil {
-						t.Errorf("Bob did not get a shield for the spoofed message")
+						ct.Errorf(t, "Bob did not get a shield for the spoofed message")
 					} else {
 						must.Equal(t, shield.Colour, api.EventShieldColourRed, "Colour of shield")
 						must.Equal(t, shield.Code, api.EventShieldCodeMismatchedSender, "Shield code")

--- a/tests/state_synchronisation_test.go
+++ b/tests/state_synchronisation_test.go
@@ -22,7 +22,7 @@ func TestSigkillBeforeKeysUploadResponse(t *testing.T) {
 		case api.ClientTypeJS:
 			testSigkillBeforeKeysUploadResponseJS(t, a)
 		default:
-			t.Fatalf("unknown lang: %s", a.Lang)
+			ct.Fatalf(t, "unknown lang: %s", a.Lang)
 		}
 	})
 }

--- a/tests/state_synchronisation_test.go
+++ b/tests/state_synchronisation_test.go
@@ -46,7 +46,7 @@ func testSigkillBeforeKeysUploadResponseRust(t *testing.T, clientType api.Client
 			if terminated.Load() {
 				// make sure the 2nd upload 200 OKs
 				if cd.ResponseCode != 200 {
-					t.Errorf("2nd /keys/upload did not 200 OK => got %v", cd.ResponseCode)
+					ct.Errorf(t, "2nd /keys/upload did not 200 OK => got %v", cd.ResponseCode)
 				}
 				t.Logf("recv 2nd /keys/upload => HTTP %d", cd.ResponseCode)
 				seenSecondKeysUploadWaiter.Finish()

--- a/tests/to_device_test.go
+++ b/tests/to_device_test.go
@@ -311,7 +311,7 @@ func TestToDeviceMessagesAreBatched(t *testing.T) {
 						return nil
 					}
 					if len(usersMap.Map()) != 100 {
-						t.Errorf("PUT /sendToDevice did not batch messages, got %d want 100", len(usersMap.Map()))
+						ct.Errorf(t, "PUT /sendToDevice did not batch messages, got %d want 100", len(usersMap.Map()))
 						t.Logf("%s", usersMap.Raw)
 					}
 					waiter.Finish()

--- a/tests/to_device_test.go
+++ b/tests/to_device_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/complement/ct"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 
 	"github.com/matrix-org/complement-crypto/internal/api"
@@ -124,7 +125,7 @@ func TestUnprocessedToDeviceMessagesArentLostOnRestart(t *testing.T) {
 			case api.ClientTypeJS:
 				testUnprocessedToDeviceMessagesArentLostOnRestartJS(t, tc, roomID, eventID)
 			default:
-				t.Fatalf("unknown lang: %s", clientType.Lang)
+				ct.Fatalf(t, "unknown lang: %s", clientType.Lang)
 			}
 		})
 	})


### PR DESCRIPTION
These are thin wrappers that set a red foreground, thus making it much easier to spot the failure in a test log.