### PR TITLE
Remove needless call to `ClientBuilder::username`.

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -106,10 +106,9 @@ func NewRustClient(t ct.TestLike, opts api.ClientCreationOpts) (api.Client, erro
 		t.Logf("setting cross process store locks holder name=%s", xprocessName)
 		ab = ab.CrossProcessLockConfig(matrix_sdk_ffi.CrossProcessLockConfigMultiProcess { xprocessName })
 	}
+
 	// @alice:hs1, FOOBAR => alice_hs1_FOOBAR
 	username := strings.Replace(opts.UserID[1:], ":", "_", -1) + "_" + opts.DeviceID
-	ab = ab.Username(username)
-
 	sessionPath := "rust_storage/" + username
 	storeKey := []byte("my_secret_thirty-two_byte_string")
 	ab = ab.SqliteStore(


### PR DESCRIPTION
Part of https://github.com/matrix-org/matrix-rust-sdk/pull/6900, `ClientBuilder::username` was unclear as to its purpose (it was purely for server discovery), so it was redundant here as a `homeserver_url` was already set.