### PR TITLE
Follow the RoomListService room subscription rename

### DIFF
--- a/internal/api/rust/rust.go
+++ b/internal/api/rust/rust.go
@@ -582,7 +582,7 @@ func (c *RustClient) SubscribeToRoom(t ct.TestLike, roomID string) error {
 	if c.syncService == nil {
 		return fmt.Errorf("cannot subscribe to room %s: StartSyncing not yet called", roomID)
 	}
-	if err := c.syncService.RoomListService().SubscribeToRooms([]string{roomID}); err != nil {
+	if err := c.syncService.RoomListService().SetRoomSubscriptions([]string{roomID}); err != nil {
 		return fmt.Errorf("cannot subscribe to room %s: %s", roomID, err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

`RoomListService::subscribeToRooms` is renamed to `setRoomSubscriptions` in matrix-org/matrix-rust-sdk#6927. This updates the one call site so the Rust client keeps compiling against the new FFI bindings.

## Affected Areas

`internal/api/rust/rust.go`, in `RustClient.SubscribeToRoom`: the call becomes `RoomListService().SetRoomSubscriptions([]string{roomID})`.

## Impact on Library Users

No impact. The upstream signature and the behaviour do not change: the call replaces the subscription set, as it did before. Only the method name changes.

## Risk Assessment

Low. The change is a rename. It needs the SDK bindings from matrix-org/matrix-rust-sdk#6927 or later; against an older SDK the build fails on the old method name.

## References

- matrix-org/matrix-rust-sdk#6927